### PR TITLE
Add CLI entry point for uvx compatibility

### DIFF
--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -341,5 +341,10 @@ async def read_semantic_paper(paper_id: str, save_path: str = "./downloads") -> 
         return ""
 
 
-if __name__ == "__main__":
+def main():
+    """Main entry point for the MCP server."""
     mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,8 @@ dependencies = [
     "httpx[socks]>=0.28.1",
 ]
 
+[project.scripts]
+paper-search-mcp = "paper_search_mcp.server:main"
+
 [tool.hatch.build.targets.wheel]
 packages = ["paper_search_mcp"]


### PR DESCRIPTION
This PR adds a CLI entry point to enable installation and running via uvx from git source.

Changes:
- Added `[project.scripts]` section to pyproject.toml pointing to `paper_search_mcp.server:main`
- Added main() function to server.py as entry point
- This enables installation via: `uvx --from git+https://github.com/openags/paper-search-mcp paper-search-mcp`

Resolves #16

@dragon-ai-agent