### PR TITLE
Add Claude Code skill + CLI as alternative to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 - [Source Strategy](#source-strategy)
 - [Sci-Hub Notice](#sci-hub-notice)
 - [Installation](#installation)
+  - [Claude Code (Skill)](#claude-code-skill--recommended-for-claude-code-users)
   - [Method 1 — Smithery](#method-1--smithery-one-command-recommended-for-claude-desktop)
   - [Method 2 — uvx](#method-2--uvx-no-install-always-latest)
   - [Method 3 — uv](#method-3--uv-persistent-install)
@@ -33,7 +34,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 
 ## Overview
 
-`paper-search-mcp` is a Python-based MCP server that enables users to search and download academic papers from various platforms. It provides tools for searching papers (e.g., `search_arxiv`) and downloading PDFs (e.g., `download_arxiv`), making it ideal for researchers and AI-driven workflows. Built with the MCP Python SDK, it integrates seamlessly with LLM clients like Claude Desktop.
+`paper-search-mcp` is a Python-based tool for searching and downloading academic papers from various platforms. It provides tools for searching papers, downloading PDFs, and extracting text, making it ideal for researchers and AI-driven workflows. It can be used as an MCP server (for Claude Desktop and other MCP clients) or as a Claude Code skill with a CLI interface.
 
 ## Project Principles
 
@@ -192,7 +193,46 @@ Sci-Hub support can remain available as an optional connector for users who expl
 
 Choose the method that best fits your workflow. All methods support the same [optional API keys](#credential--api-key-requirements).
 
-> **Config file locations**
+---
+
+### Claude Code (Skill) — recommended for Claude Code users
+
+Install as a Claude Code skill instead of an MCP server. This gives Claude automatic access to paper search when you mention finding papers, academic literature, etc. — no MCP configuration needed.
+
+**Prerequisites**: [uv](https://docs.astral.sh/uv/getting-started/installation/) and [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview).
+
+**Step 1 — Clone the repo:**
+
+```bash
+git clone https://github.com/openags/paper-search-mcp.git ~/paper-search-mcp
+```
+
+**Step 2 — Install the skill:**
+
+```bash
+mkdir -p ~/.claude/skills/paper-search
+cp ~/paper-search-mcp/claude-code/SKILL.md ~/.claude/skills/paper-search/SKILL.md
+```
+
+**Step 3 — Update the repo path in the skill:**
+
+Edit `~/.claude/skills/paper-search/SKILL.md` and replace every `<REPO_PATH>` with the absolute path to your clone (e.g. `/Users/yourname/paper-search-mcp`).
+
+**Step 4 (optional) — Configure API keys:**
+
+Create a `.env` file in the repo root for optional API keys (see [Environment Variables](#environment-variables-env-file)).
+
+**That's it.** Next time you start Claude Code, just ask it to find papers — the skill activates automatically. For example:
+
+- "Find me recent papers on CRISPR base editing"
+- "Search arxiv and semantic scholar for transformer attention mechanisms"
+- "Download the PDF for arxiv paper 2106.12345"
+
+The skill uses a CLI (`paper-search`) that wraps the same library as the MCP server, outputting JSON for search/download and plain text for read.
+
+---
+
+> **MCP Server Config file locations** (for methods below)
 > - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 > - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 > - **Linux**: `~/.config/Claude/claude_desktop_config.json`

--- a/claude-code/SKILL.md
+++ b/claude-code/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: paper-search
+description: Search, download, and read academic papers from 20+ sources (arXiv, PubMed, Semantic Scholar, CrossRef, etc). Use when the user asks to find papers, search for research, look up academic literature, download a paper PDF, or extract text from a paper.
+---
+
+# Paper Search
+
+Search, download, and read academic papers via the `paper-search` CLI.
+
+## CLI Usage
+
+All commands run via:
+```bash
+uv run --directory <REPO_PATH> paper-search <command> [args]
+```
+
+Replace `<REPO_PATH>` with the absolute path to your clone of this repository.
+
+### Search
+```bash
+uv run --directory <REPO_PATH> paper-search search "<query>" -n <max_per_source> -s <sources> -y <year>
+```
+- `-n`: results per source (default: 5)
+- `-s`: comma-separated sources or "all" (default: all)
+- `-y`: year filter for Semantic Scholar (e.g. "2020", "2018-2022")
+
+For speed, prefer targeted sources (`-s arxiv,semantic,crossref`) over "all" unless broad coverage is needed.
+
+### Download PDF
+```bash
+uv run --directory <REPO_PATH> paper-search download <source> <paper_id> [-o ./downloads]
+```
+
+### Read (extract text)
+```bash
+uv run --directory <REPO_PATH> paper-search read <source> <paper_id> [-o ./downloads]
+```
+
+### List sources
+```bash
+uv run --directory <REPO_PATH> paper-search sources
+```
+
+## Output
+
+`search` and `download` return JSON. `read` returns plain text. Config warnings go to stderr and can be ignored.
+
+## Sources
+
+arxiv, pubmed, biorxiv, medrxiv, google_scholar, iacr, semantic, crossref, openalex, pmc, core, europepmc, dblp, openaire, citeseerx, doaj, base, zenodo, hal, ssrn, unpaywall
+
+Optional (env vars): ieee (`IEEE_API_KEY`), acm (`ACM_API_KEY`)
+
+## Workflow
+
+1. Search with targeted sources to find papers
+2. Present results as a table: title, authors, year, source, DOI/URL
+3. If the user wants full text, use `read <source> <paper_id>`
+4. If the user wants the PDF, use `download <source> <paper_id>` and report the saved path

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""CLI interface for paper-search — search, download, and read academic papers."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any, Dict, List, Optional
+
+from .config import get_env
+from .academic_platforms.arxiv import ArxivSearcher
+from .academic_platforms.pubmed import PubMedSearcher
+from .academic_platforms.biorxiv import BioRxivSearcher
+from .academic_platforms.medrxiv import MedRxivSearcher
+from .academic_platforms.google_scholar import GoogleScholarSearcher
+from .academic_platforms.iacr import IACRSearcher
+from .academic_platforms.semantic import SemanticSearcher
+from .academic_platforms.crossref import CrossRefSearcher
+from .academic_platforms.openalex import OpenAlexSearcher
+from .academic_platforms.pmc import PMCSearcher
+from .academic_platforms.core import CORESearcher
+from .academic_platforms.europepmc import EuropePMCSearcher
+from .academic_platforms.sci_hub import SciHubFetcher
+from .academic_platforms.dblp import DBLPSearcher
+from .academic_platforms.openaire import OpenAiresearcher
+from .academic_platforms.citeseerx import CiteSeerXSearcher
+from .academic_platforms.doaj import DOAJSearcher
+from .academic_platforms.base_search import BASESearcher
+from .academic_platforms.unpaywall import UnpaywallResolver, UnpaywallSearcher
+from .academic_platforms.zenodo import ZenodoSearcher
+from .academic_platforms.hal import HALSearcher
+from .academic_platforms.ssrn import SSRNSearcher
+from .utils import extract_doi
+
+# ---------------------------------------------------------------------------
+# Searcher registry
+# ---------------------------------------------------------------------------
+
+SEARCHERS: Dict[str, Any] = {}
+
+
+def _init_searchers() -> None:
+    """Lazily initialize searcher instances."""
+    if SEARCHERS:
+        return
+
+    SEARCHERS["arxiv"] = ArxivSearcher()
+    SEARCHERS["pubmed"] = PubMedSearcher()
+    SEARCHERS["biorxiv"] = BioRxivSearcher()
+    SEARCHERS["medrxiv"] = MedRxivSearcher()
+    SEARCHERS["google_scholar"] = GoogleScholarSearcher()
+    SEARCHERS["iacr"] = IACRSearcher()
+    SEARCHERS["semantic"] = SemanticSearcher()
+    SEARCHERS["crossref"] = CrossRefSearcher()
+    SEARCHERS["openalex"] = OpenAlexSearcher()
+    SEARCHERS["pmc"] = PMCSearcher()
+    SEARCHERS["core"] = CORESearcher()
+    SEARCHERS["europepmc"] = EuropePMCSearcher()
+    SEARCHERS["dblp"] = DBLPSearcher()
+    SEARCHERS["openaire"] = OpenAiresearcher()
+    SEARCHERS["citeseerx"] = CiteSeerXSearcher()
+    SEARCHERS["doaj"] = DOAJSearcher()
+    SEARCHERS["base"] = BASESearcher()
+    unpaywall_resolver = UnpaywallResolver()
+    SEARCHERS["unpaywall"] = UnpaywallSearcher(resolver=unpaywall_resolver)
+    SEARCHERS["zenodo"] = ZenodoSearcher()
+    SEARCHERS["hal"] = HALSearcher()
+    SEARCHERS["ssrn"] = SSRNSearcher()
+
+    # Optional paid connectors
+    ieee_key = get_env("IEEE_API_KEY", "")
+    if ieee_key:
+        from .academic_platforms.ieee import IEEESearcher
+        SEARCHERS["ieee"] = IEEESearcher()
+
+    acm_key = get_env("ACM_API_KEY", "")
+    if acm_key:
+        from .academic_platforms.acm import ACMSearcher
+        SEARCHERS["acm"] = ACMSearcher()
+
+
+ALL_SOURCES = [
+    "arxiv", "pubmed", "biorxiv", "medrxiv", "google_scholar", "iacr",
+    "semantic", "crossref", "openalex", "pmc", "core", "europepmc",
+    "dblp", "openaire", "citeseerx", "doaj", "base", "zenodo", "hal",
+    "ssrn", "unpaywall",
+]
+
+
+def _parse_sources(sources: str) -> List[str]:
+    if not sources or sources.strip().lower() == "all":
+        return [s for s in ALL_SOURCES if s in SEARCHERS]
+    normalized = [p.strip().lower() for p in sources.split(",") if p.strip()]
+    return [s for s in normalized if s in SEARCHERS]
+
+
+def _paper_unique_key(paper: Dict[str, Any]) -> str:
+    doi = (paper.get("doi") or "").strip().lower()
+    if doi:
+        return f"doi:{doi}"
+    title = (paper.get("title") or "").strip().lower()
+    authors = (paper.get("authors") or "").strip().lower()
+    if title:
+        return f"title:{title}|authors:{authors}"
+    return f"id:{(paper.get('paper_id') or '').strip().lower()}"
+
+
+def _dedupe(papers: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    seen: set[str] = set()
+    out: list[Dict[str, Any]] = []
+    for p in papers:
+        k = _paper_unique_key(p)
+        if k not in seen:
+            seen.add(k)
+            out.append(p)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Async helpers
+# ---------------------------------------------------------------------------
+
+async def _async_search(searcher: Any, query: str, max_results: int, **kwargs) -> List[Dict]:
+    if kwargs:
+        papers = await asyncio.to_thread(searcher.search, query, max_results=max_results, **kwargs)
+    else:
+        papers = await asyncio.to_thread(searcher.search, query, max_results=max_results)
+    return [p.to_dict() for p in papers]
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+async def cmd_search(args: argparse.Namespace) -> None:
+    _init_searchers()
+    selected = _parse_sources(args.sources)
+    if not selected:
+        print(json.dumps({"error": "No valid sources selected", "available": sorted(SEARCHERS.keys())}))
+        return
+
+    tasks = {}
+    for src in selected:
+        searcher = SEARCHERS[src]
+        extra = {}
+        if src == "semantic" and args.year:
+            extra["year"] = args.year
+        tasks[src] = _async_search(searcher, args.query, args.max_results, **extra)
+
+    names = list(tasks.keys())
+    results = await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+    merged: List[Dict[str, Any]] = []
+    errors: Dict[str, str] = {}
+    source_counts: Dict[str, int] = {}
+
+    for name, result in zip(names, results):
+        if isinstance(result, Exception):
+            errors[name] = str(result)
+            source_counts[name] = 0
+        else:
+            source_counts[name] = len(result)
+            for p in result:
+                if not p.get("source"):
+                    p["source"] = name
+                merged.append(p)
+
+    deduped = _dedupe(merged)
+
+    output = {
+        "query": args.query,
+        "sources_used": names,
+        "source_results": source_counts,
+        "errors": errors,
+        "total": len(deduped),
+        "papers": deduped,
+    }
+    print(json.dumps(output, indent=2, default=str))
+
+
+async def cmd_download(args: argparse.Namespace) -> None:
+    _init_searchers()
+    source = args.source.strip().lower()
+
+    if source not in SEARCHERS:
+        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(SEARCHERS.keys())}))
+        return
+
+    searcher = SEARCHERS[source]
+    try:
+        result = await asyncio.to_thread(searcher.download_pdf, args.paper_id, args.save_path)
+        print(json.dumps({"status": "ok", "path": result}))
+    except Exception as e:
+        print(json.dumps({"status": "error", "message": str(e)}))
+
+
+async def cmd_read(args: argparse.Namespace) -> None:
+    _init_searchers()
+    source = args.source.strip().lower()
+
+    if source not in SEARCHERS:
+        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(SEARCHERS.keys())}))
+        return
+
+    searcher = SEARCHERS[source]
+    try:
+        text = await asyncio.to_thread(searcher.read_paper, args.paper_id, args.save_path)
+        print(text)
+    except Exception as e:
+        print(json.dumps({"status": "error", "message": str(e)}))
+
+
+async def cmd_sources(args: argparse.Namespace) -> None:
+    _init_searchers()
+    print(json.dumps({"sources": sorted(SEARCHERS.keys())}, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="paper-search",
+        description="Search, download, and read academic papers from 20+ sources.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # search
+    p_search = sub.add_parser("search", help="Search for papers across academic platforms")
+    p_search.add_argument("query", help="Search query")
+    p_search.add_argument("-n", "--max-results", type=int, default=5, help="Max results per source (default: 5)")
+    p_search.add_argument("-s", "--sources", default="all",
+                          help="Comma-separated sources or 'all' (default: all)")
+    p_search.add_argument("-y", "--year", default=None,
+                          help="Year filter for Semantic Scholar (e.g. '2020', '2018-2022')")
+
+    # download
+    p_dl = sub.add_parser("download", help="Download a paper PDF")
+    p_dl.add_argument("source", help="Source platform (e.g. arxiv, semantic)")
+    p_dl.add_argument("paper_id", help="Paper identifier")
+    p_dl.add_argument("-o", "--save-path", default="./downloads", help="Save directory (default: ./downloads)")
+
+    # read
+    p_read = sub.add_parser("read", help="Download and extract text from a paper")
+    p_read.add_argument("source", help="Source platform (e.g. arxiv, semantic)")
+    p_read.add_argument("paper_id", help="Paper identifier")
+    p_read.add_argument("-o", "--save-path", default="./downloads", help="Save directory (default: ./downloads)")
+
+    # sources
+    sub.add_parser("sources", help="List available sources")
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    dispatch = {
+        "search": cmd_search,
+        "download": cmd_download,
+        "read": cmd_read,
+        "sources": cmd_sources,
+    }
+
+    asyncio.run(dispatch[args.command](args))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ Issues = "https://github.com/openags/paper-search-mcp/issues"
 
 [project.scripts]
 paper-search-mcp = "paper_search_mcp.server:main"
+paper-search = "paper_search_mcp.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["paper_search_mcp"]


### PR DESCRIPTION
## Summary

- Adds a `paper-search` CLI entry point (`paper_search_mcp/cli.py`) with `search`, `download`, `read`, and `sources` subcommands that output JSON/text
- Adds `claude-code/SKILL.md` so users can install paper-search as a Claude Code skill (auto-activates when users ask about academic papers)
- Updates README with Claude Code installation instructions as the first option
- One new line in `pyproject.toml` to register the `paper-search` console script

The existing MCP server (`paper-search-mcp`) is completely unchanged. This is purely additive — the CLI reuses the same searcher library and provides an alternative interface for Claude Code users who don't want to configure an MCP server.

## Files changed

| File | Change |
|------|--------|
| `paper_search_mcp/cli.py` | New CLI with search/download/read/sources subcommands |
| `pyproject.toml` | Add `paper-search` entry point (1 line) |
| `claude-code/SKILL.md` | Skill file for Claude Code users to copy to `~/.claude/skills/` |
| `README.md` | Add Claude Code installation section, update overview |

## Test plan

- [x] `uv run paper-search sources` — lists all 21 sources
- [x] `uv run paper-search search "query" -n 2 -s arxiv` — returns JSON with papers
- [ ] Verify existing MCP server still works (`uv run paper-search-mcp`)
- [ ] Copy skill to `~/.claude/skills/paper-search/` and verify Claude Code auto-activates on paper search requests