### PR TITLE
fix: migrate from pypdf2 to pypdf

### DIFF
--- a/paper_search_mcp/academic_platforms/arxiv.py
+++ b/paper_search_mcp/academic_platforms/arxiv.py
@@ -7,7 +7,7 @@ import time
 from ..paper import Paper
 from ..utils import extract_doi
 from .base import PaperSource
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 import os
 
 class ArxivSearcher(PaperSource):

--- a/paper_search_mcp/academic_platforms/biorxiv.py
+++ b/paper_search_mcp/academic_platforms/biorxiv.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime, timedelta
 from ..paper import Paper
 from .base import PaperSource
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 class BioRxivSearcher(PaperSource):
     """Searcher for bioRxiv papers"""

--- a/paper_search_mcp/academic_platforms/core.py
+++ b/paper_search_mcp/academic_platforms/core.py
@@ -10,7 +10,7 @@ from ..paper import Paper
 from ..utils import extract_doi
 from ..config import get_env
 from .base import PaperSource
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 logger = logging.getLogger(__name__)
 

--- a/paper_search_mcp/academic_platforms/doaj.py
+++ b/paper_search_mcp/academic_platforms/doaj.py
@@ -431,7 +431,7 @@ class DOAJSearcher(PaperSource):
             pdf_path = self.download_pdf(paper_id, save_path)
 
             # Extract text from PDF
-            from PyPDF2 import PdfReader
+            from pypdf import PdfReader
             reader = PdfReader(pdf_path)
             text = ""
             for page in reader.pages:

--- a/paper_search_mcp/academic_platforms/europepmc.py
+++ b/paper_search_mcp/academic_platforms/europepmc.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ..paper import Paper
 from ..utils import extract_doi
 from .base import PaperSource
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 logger = logging.getLogger(__name__)
 

--- a/paper_search_mcp/academic_platforms/hal.py
+++ b/paper_search_mcp/academic_platforms/hal.py
@@ -167,16 +167,17 @@ class HALSearcher(PaperSource):
             return path
 
         try:
-            try:
-                from PyPDF2 import PdfReader
-            except ImportError:
-                from pypdf import PdfReader
+            from pypdf import PdfReader
 
             reader = PdfReader(path)
-            text_parts = [page.extract_text() for page in reader.pages if page.extract_text()]
-            return "\n\n".join(text_parts) if text_parts else "No extractable text in PDF."
+            text_parts = [
+                page.extract_text() for page in reader.pages if page.extract_text()
+            ]
+            return (
+                "\n\n".join(text_parts) if text_parts else "No extractable text in PDF."
+            )
         except ImportError:
-            return f"PDF downloaded to {path}. Install 'PyPDF2' or 'pypdf' to extract text."
+            return f"PDF downloaded to {path}. Install 'pypdf' to extract text."
         except Exception as exc:
             return f"PDF downloaded to {path} but text extraction failed: {exc}"
 
@@ -238,7 +239,9 @@ class HALSearcher(PaperSource):
                 doi = doi[0] if doi else ""
 
             year = doc.get("publicationDateY_i") or doc.get("producedDateY_i", "")
-            pub_date = str(year) if year else (doc.get("submittedDate_s", "") or "")[:10]
+            pub_date = (
+                str(year) if year else (doc.get("submittedDate_s", "") or "")[:10]
+            )
 
             pdf_url = doc.get("fileMain_s", "") or ""
             record_url = doc.get("uri_s", f"https://hal.archives-ouvertes.fr/{hal_id}")

--- a/paper_search_mcp/academic_platforms/iacr.py
+++ b/paper_search_mcp/academic_platforms/iacr.py
@@ -8,7 +8,7 @@ from ..paper import Paper
 from ..utils import extract_doi
 from .base import PaperSource
 import logging
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 import os
 
 logger = logging.getLogger(__name__)
@@ -181,7 +181,9 @@ class IACRSearcher(PaperSource):
                 if len(papers) >= max_results:
                     break
 
-                logger.info(f"Processing paper {i+1}/{min(len(results), max_results)}")
+                logger.info(
+                    f"Processing paper {i + 1}/{min(len(results), max_results)}"
+                )
                 paper = self._parse_paper(item, fetch_details=fetch_details)
                 if paper:
                     papers.append(paper)
@@ -251,7 +253,7 @@ class IACRSearcher(PaperSource):
             with open(pdf_path, "wb") as f:
                 f.write(pdf_response.content)
 
-            # Extract text using PyPDF2
+            # Extract text using PyPDF
             reader = PdfReader(pdf_path)
             text = ""
 

--- a/paper_search_mcp/academic_platforms/medrxiv.py
+++ b/paper_search_mcp/academic_platforms/medrxiv.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime, timedelta
 from ..paper import Paper
 from .base import PaperSource
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 class MedRxivSearcher(PaperSource):
     """Searcher for medRxiv papers"""

--- a/paper_search_mcp/academic_platforms/oaipmh.py
+++ b/paper_search_mcp/academic_platforms/oaipmh.py
@@ -428,7 +428,7 @@ class OAIPMHSearcher(PaperSource):
             pdf_path = self.download_pdf(paper_id, save_path)
 
             # Extract text from PDF
-            from PyPDF2 import PdfReader
+            from pypdf import PdfReader
             reader = PdfReader(pdf_path)
             text = ""
             for page in reader.pages:

--- a/paper_search_mcp/academic_platforms/pmc.py
+++ b/paper_search_mcp/academic_platforms/pmc.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from ..paper import Paper
 from ..utils import extract_doi
 from .base import PaperSource
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 logger = logging.getLogger(__name__)
 

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -9,7 +9,7 @@ from ..paper import Paper
 from ..utils import extract_doi
 from .base import PaperSource
 import logging
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 import re
 from ..config import get_env
 
@@ -53,90 +53,92 @@ class SemanticSearcher(PaperSource):
         """Extract URL from disclaimer text"""
         # 匹配常见的 URL 模式
         url_patterns = [
-            r'https?://[^\s,)]+',  # 基本的 HTTP/HTTPS URL
-            r'https?://arxiv\.org/abs/[^\s,)]+',  # arXiv 链接
-            r'https?://[^\s,)]*\.pdf',  # PDF 文件链接
+            r"https?://[^\s,)]+",  # 基本的 HTTP/HTTPS URL
+            r"https?://arxiv\.org/abs/[^\s,)]+",  # arXiv 链接
+            r"https?://[^\s,)]*\.pdf",  # PDF 文件链接
         ]
-        
+
         all_urls = []
         for pattern in url_patterns:
             matches = re.findall(pattern, disclaimer)
             all_urls.extend(matches)
-        
+
         if not all_urls:
             return ""
-        
-        doi_urls = [url for url in all_urls if 'doi.org' in url]
+
+        doi_urls = [url for url in all_urls if "doi.org" in url]
         if doi_urls:
             return doi_urls[0]
-        
-        non_unpaywall_urls = [url for url in all_urls if 'unpaywall.org' not in url]
+
+        non_unpaywall_urls = [url for url in all_urls if "unpaywall.org" not in url]
         if non_unpaywall_urls:
             url = non_unpaywall_urls[0]
-            if 'arxiv.org/abs/' in url:
-                pdf_url = url.replace('/abs/', '/pdf/')
+            if "arxiv.org/abs/" in url:
+                pdf_url = url.replace("/abs/", "/pdf/")
                 return pdf_url
             return url
-        
+
         if all_urls:
             url = all_urls[0]
-            if 'arxiv.org/abs/' in url:
-                pdf_url = url.replace('/abs/', '/pdf/')
+            if "arxiv.org/abs/" in url:
+                pdf_url = url.replace("/abs/", "/pdf/")
                 return pdf_url
             return url
-        
+
         return ""
 
     def _parse_paper(self, item) -> Optional[Paper]:
         """Parse single paper entry from Semantic Scholar HTML and optionally fetch detailed info"""
         try:
-            authors = [author['name'] for author in item.get('authors', [])]
-            
+            authors = [author["name"] for author in item.get("authors", [])]
+
             # Parse the publication date
-            published_date = self._parse_date(item.get('publicationDate', ''))
-            
+            published_date = self._parse_date(item.get("publicationDate", ""))
+
             # Safely get PDF URL - 支持从 disclaimer 中提取
             pdf_url = ""
-            if item.get('openAccessPdf'):
-                open_access_pdf = item['openAccessPdf']
+            if item.get("openAccessPdf"):
+                open_access_pdf = item["openAccessPdf"]
                 # 首先尝试直接获取 URL
-                if open_access_pdf.get('url'):
-                    pdf_url = open_access_pdf['url']
+                if open_access_pdf.get("url"):
+                    pdf_url = open_access_pdf["url"]
                 # 如果 URL 为空但有 disclaimer，尝试从 disclaimer 中提取
-                elif open_access_pdf.get('disclaimer'):
-                    pdf_url = self._extract_url_from_disclaimer(open_access_pdf['disclaimer'])
-            
+                elif open_access_pdf.get("disclaimer"):
+                    pdf_url = self._extract_url_from_disclaimer(
+                        open_access_pdf["disclaimer"]
+                    )
+
             # Safely get DOI
             doi = ""
-            if item.get('externalIds') and item['externalIds'].get('DOI'):
-                doi = item['externalIds']['DOI']
-            
-            if not doi and item.get('abstract'):
-                doi = extract_doi(item['abstract'])
-            
+            if item.get("externalIds") and item["externalIds"].get("DOI"):
+                doi = item["externalIds"]["DOI"]
+
+            if not doi and item.get("abstract"):
+                doi = extract_doi(item["abstract"])
+
             # Safely get categories
-            categories = item.get('fieldsOfStudy', [])
+            categories = item.get("fieldsOfStudy", [])
             if not categories:
                 categories = []
-            
+
             return Paper(
-                paper_id=item['paperId'],
-                title=item['title'],
+                paper_id=item["paperId"],
+                title=item["title"],
                 authors=authors,
-                abstract=item.get('abstract', ''),
-                url=item.get('url', ''),
+                abstract=item.get("abstract", ""),
+                url=item.get("url", ""),
                 pdf_url=pdf_url,
                 published_date=published_date,
                 source="semantic",
                 categories=categories,
                 doi=doi,
-                citations=item.get('citationCount', 0),
+                citations=item.get("citationCount", 0),
             )
 
         except Exception as e:
             logger.warning(f"Failed to parse Semantic paper: {e}")
             return None
-        
+
     @staticmethod
     def get_api_key() -> Optional[str]:
         """
@@ -145,10 +147,12 @@ class SemanticSearcher(PaperSource):
         """
         api_key = get_env("SEMANTIC_SCHOLAR_API_KEY", "")
         if not api_key or api_key.strip() == "":
-            logger.warning("No SEMANTIC_SCHOLAR_API_KEY set or it's empty. Using unauthenticated access with lower rate limits.")
+            logger.warning(
+                "No SEMANTIC_SCHOLAR_API_KEY set or it's empty. Using unauthenticated access with lower rate limits."
+            )
             return None
         return api_key.strip()
-    
+
     def request_api(self, path: str, params: dict) -> dict:
         """
         Make a request to the Semantic Scholar API with optional API key.
@@ -157,58 +161,103 @@ class SemanticSearcher(PaperSource):
         api_key = self.get_api_key()
         retry_delay = 5 if api_key is None else 2
         has_retried_without_key = False
-        
+
         for attempt in range(max_retries):
             try:
                 headers = {"x-api-key": api_key} if api_key else {}
                 url = f"{self.SEMANTIC_BASE_URL}/{path}"
-                response = self.session.get(url, params=params, headers=headers, timeout=30)
+                response = self.session.get(
+                    url, params=params, headers=headers, timeout=30
+                )
 
-                if response.status_code == 403 and api_key and not has_retried_without_key:
-                    logger.warning("Semantic Scholar API key was rejected (403). Retrying without API key.")
+                if (
+                    response.status_code == 403
+                    and api_key
+                    and not has_retried_without_key
+                ):
+                    logger.warning(
+                        "Semantic Scholar API key was rejected (403). Retrying without API key."
+                    )
                     api_key = None
                     has_retried_without_key = True
                     continue
-                
+
                 # 检查是否是429错误（限流）
                 if response.status_code == 429:
                     if attempt < max_retries - 1:
                         retry_after = response.headers.get("Retry-After")
-                        wait_time = int(retry_after) if retry_after and retry_after.isdigit() else retry_delay * (2 ** attempt)
-                        logger.warning(f"Rate limited (429). Waiting {wait_time} seconds before retry {attempt + 1}/{max_retries}")
+                        wait_time = (
+                            int(retry_after)
+                            if retry_after and retry_after.isdigit()
+                            else retry_delay * (2**attempt)
+                        )
+                        logger.warning(
+                            f"Rate limited (429). Waiting {wait_time} seconds before retry {attempt + 1}/{max_retries}"
+                        )
                         time.sleep(wait_time)
                         continue
                     else:
-                        logger.error(f"Rate limited (429) after {max_retries} attempts. Please wait before making more requests.")
-                        return {"error": "rate_limited", "status_code": 429, "message": "Too many requests. Please wait before retrying."}
-                
+                        logger.error(
+                            f"Rate limited (429) after {max_retries} attempts. Please wait before making more requests."
+                        )
+                        return {
+                            "error": "rate_limited",
+                            "status_code": 429,
+                            "message": "Too many requests. Please wait before retrying.",
+                        }
+
                 response.raise_for_status()
                 return response
-                
+
             except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 403 and api_key and not has_retried_without_key:
-                    logger.warning("Semantic Scholar API key was rejected (403). Retrying without API key.")
+                if (
+                    e.response.status_code == 403
+                    and api_key
+                    and not has_retried_without_key
+                ):
+                    logger.warning(
+                        "Semantic Scholar API key was rejected (403). Retrying without API key."
+                    )
                     api_key = None
                     has_retried_without_key = True
                     continue
                 if e.response.status_code == 429:
                     if attempt < max_retries - 1:
                         retry_after = e.response.headers.get("Retry-After")
-                        wait_time = int(retry_after) if retry_after and retry_after.isdigit() else retry_delay * (2 ** attempt)
-                        logger.warning(f"Rate limited (429). Waiting {wait_time} seconds before retry {attempt + 1}/{max_retries}")
+                        wait_time = (
+                            int(retry_after)
+                            if retry_after and retry_after.isdigit()
+                            else retry_delay * (2**attempt)
+                        )
+                        logger.warning(
+                            f"Rate limited (429). Waiting {wait_time} seconds before retry {attempt + 1}/{max_retries}"
+                        )
                         time.sleep(wait_time)
                         continue
                     else:
-                        logger.error(f"Rate limited (429) after {max_retries} attempts. Please wait before making more requests.")
-                        return {"error": "rate_limited", "status_code": 429, "message": "Too many requests. Please wait before retrying."}
+                        logger.error(
+                            f"Rate limited (429) after {max_retries} attempts. Please wait before making more requests."
+                        )
+                        return {
+                            "error": "rate_limited",
+                            "status_code": 429,
+                            "message": "Too many requests. Please wait before retrying.",
+                        }
                 else:
                     logger.error(f"HTTP Error requesting API: {e}")
-                    return {"error": "http_error", "status_code": e.response.status_code, "message": str(e)}
+                    return {
+                        "error": "http_error",
+                        "status_code": e.response.status_code,
+                        "message": str(e),
+                    }
             except Exception as e:
                 logger.error(f"Error requesting API: {e}")
                 return {"error": "general_error", "message": str(e)}
-        
-        return {"error": "max_retries_exceeded", "message": "Maximum retry attempts exceeded"}
+
+        return {
+            "error": "max_retries_exceeded",
+            "message": "Maximum retry attempts exceeded",
+        }
 
     def search(
         self,
@@ -260,7 +309,7 @@ class SemanticSearcher(PaperSource):
                 params["year"] = year
             # Make request
             response = self.request_api("paper/search", params)
-            
+
             # Check for errors
             if isinstance(response, dict) and "error" in response:
                 error_msg = response.get("message", "Unknown error")
@@ -269,15 +318,17 @@ class SemanticSearcher(PaperSource):
                 else:
                     logger.error(f"Semantic Scholar API error: {error_msg}")
                 return papers
-            
+
             # Check response status code
-            if not hasattr(response, 'status_code') or response.status_code != 200:
-                status_code = getattr(response, 'status_code', 'unknown')
-                logger.error(f"Semantic Scholar search failed with status {status_code}")
+            if not hasattr(response, "status_code") or response.status_code != 200:
+                status_code = getattr(response, "status_code", "unknown")
+                logger.error(
+                    f"Semantic Scholar search failed with status {status_code}"
+                )
                 return papers
-                
+
             data = response.json()
-            results = data['data']
+            results = data["data"]
 
             if not results:
                 logger.info("No results found for the query")
@@ -288,7 +339,9 @@ class SemanticSearcher(PaperSource):
                 if len(papers) >= max_results:
                     break
 
-                logger.info(f"Processing paper {i+1}/{min(len(results), max_results)}")
+                logger.info(
+                    f"Processing paper {i + 1}/{min(len(results), max_results)}"
+                )
                 paper = self._parse_paper(item)
                 if paper:
                     papers.append(paper)
@@ -313,7 +366,7 @@ class SemanticSearcher(PaperSource):
             - PMCID:<id> (e.g., "PMCID:2323736")
             - URL:<url> (e.g., "URL:https://arxiv.org/abs/2106.15928v1")
             save_path: Path to save the PDF
-            
+
         Returns:
             str: Path to downloaded file or error message
         """
@@ -324,13 +377,13 @@ class SemanticSearcher(PaperSource):
             pdf_url = paper.pdf_url
             pdf_response = requests.get(pdf_url, timeout=30)
             pdf_response.raise_for_status()
-            
+
             # Create download directory if it doesn't exist
             os.makedirs(save_path, exist_ok=True)
-            
+
             filename = f"semantic_{paper_id.replace('/', '_')}.pdf"
             pdf_path = os.path.join(save_path, filename)
-            
+
             with open(pdf_path, "wb") as f:
                 f.write(pdf_response.content)
             return pdf_path
@@ -375,7 +428,7 @@ class SemanticSearcher(PaperSource):
             else:
                 paper = self.get_paper_details(paper_id)
 
-            # Extract text using PyPDF2
+            # Extract text using PyPDF
             reader = PdfReader(pdf_path)
             text = ""
 
@@ -447,9 +500,9 @@ class SemanticSearcher(PaperSource):
             params = {
                 "fields": ",".join(fields),
             }
-            
+
             response = self.request_api(f"paper/{paper_id}", params)
-            
+
             # Check for errors
             if isinstance(response, dict) and "error" in response:
                 error_msg = response.get("message", "Unknown error")
@@ -458,13 +511,15 @@ class SemanticSearcher(PaperSource):
                 else:
                     logger.error(f"Semantic Scholar API error: {error_msg}")
                 return None
-            
+
             # Check response status code
-            if not hasattr(response, 'status_code') or response.status_code != 200:
-                status_code = getattr(response, 'status_code', 'unknown')
-                logger.error(f"Semantic Scholar paper details fetch failed with status {status_code}")
+            if not hasattr(response, "status_code") or response.status_code != 200:
+                status_code = getattr(response, "status_code", "unknown")
+                logger.error(
+                    f"Semantic Scholar paper details fetch failed with status {status_code}"
+                )
                 return None
-                
+
             results = response.json()
             paper = self._parse_paper(results)
             if paper:
@@ -528,4 +583,3 @@ if __name__ == "__main__":
             print(f"Could not fetch details for paper {test_paper_id}")
     except Exception as e:
         print(f"Error fetching paper details: {e}")
-    

--- a/paper_search_mcp/academic_platforms/ssrn.py
+++ b/paper_search_mcp/academic_platforms/ssrn.py
@@ -168,7 +168,7 @@ class SSRNSearcher(PaperSource):
             return pdf_path
 
         try:
-            from PyPDF2 import PdfReader
+            from pypdf import PdfReader
 
             reader = PdfReader(pdf_path)
             text_parts = []

--- a/paper_search_mcp/academic_platforms/zenodo.py
+++ b/paper_search_mcp/academic_platforms/zenodo.py
@@ -172,16 +172,17 @@ class ZenodoSearcher(PaperSource):
             return path  # error message
 
         try:
-            try:
-                from PyPDF2 import PdfReader
-            except ImportError:
-                from pypdf import PdfReader
+            from pypdf import PdfReader
 
             reader = PdfReader(path)
-            text_parts = [page.extract_text() for page in reader.pages if page.extract_text()]
-            return "\n\n".join(text_parts) if text_parts else "No extractable text in PDF."
+            text_parts = [
+                page.extract_text() for page in reader.pages if page.extract_text()
+            ]
+            return (
+                "\n\n".join(text_parts) if text_parts else "No extractable text in PDF."
+            )
         except ImportError:
-            return f"PDF downloaded to {path}. Install 'PyPDF2' or 'pypdf' to extract text."
+            return f"PDF downloaded to {path}. Install 'pypdf' to extract text."
         except Exception as exc:
             return f"PDF downloaded to {path} but text extraction failed: {exc}"
 
@@ -232,13 +233,15 @@ class ZenodoSearcher(PaperSource):
 
             creators = meta.get("creators", [])
             authors = ", ".join(
-                c.get("name", "") or f"{c.get('given_name', '')} {c.get('family_name', '')}".strip()
+                c.get("name", "")
+                or f"{c.get('given_name', '')} {c.get('family_name', '')}".strip()
                 for c in creators
             )
 
             abstract = (meta.get("description") or "").strip()
             # Zenodo descriptions can contain HTML — strip tags minimally
             import re
+
             abstract = re.sub(r"<[^>]+>", " ", abstract).strip()
 
             pub_date = meta.get("publication_date", "")
@@ -253,7 +256,9 @@ class ZenodoSearcher(PaperSource):
                     pdf_url = links.get("self", "") or links.get("download", "")
                     break
 
-            record_url = hit.get("links", {}).get("html", f"https://zenodo.org/record/{record_id}")
+            record_url = hit.get("links", {}).get(
+                "html", f"https://zenodo.org/record/{record_id}"
+            )
 
             return Paper(
                 paper_id=f"zenodo:{record_id}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,20 @@ build-backend = "hatchling.build"
 [project]
 name = "paper-search-mcp"
 version = "0.1.4"
-authors = [
-  { name = "P.S Zhang", email = "pengsongzhang96@gmail.com" },
-]
+authors = [{ name = "P.S Zhang", email = "pengsongzhang96@gmail.com" }]
 description = "A MCP server for searching and downloading academic papers from multiple sources."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
-keywords = ["mcp", "academic", "papers", "search", "arxiv", "pubmed", "semantic-scholar"]
+keywords = [
+    "mcp",
+    "academic",
+    "papers",
+    "search",
+    "arxiv",
+    "pubmed",
+    "semantic-scholar",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
@@ -28,8 +34,8 @@ dependencies = [
     "requests",
     "feedparser",
     "fastmcp",
+    "pypdf",
     "mcp[cli]>=1.6.0",
-    "PyPDF2>=3.0.0",
     "beautifulsoup4>=4.12.0",
     "lxml>=4.9.0",
     "httpx[socks]>=0.28.1",

--- a/uv.lock
+++ b/uv.lock
@@ -941,7 +941,7 @@ dependencies = [
     { name = "httpx", extra = ["socks"] },
     { name = "lxml" },
     { name = "mcp", extra = ["cli"] },
-    { name = "pypdf2" },
+    { name = "pypdf" },
     { name = "requests" },
 ]
 
@@ -953,7 +953,7 @@ requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=4.9.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
-    { name = "pypdf2", specifier = ">=3.0.0" },
+    { name = "pypdf" },
     { name = "requests" },
 ]
 
@@ -1188,12 +1188,15 @@ crypto = [
 ]
 
 [[package]]
-name = "pypdf2"
-version = "3.0.1"
+name = "pypdf"
+version = "6.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/bb/18dc3062d37db6c491392007dfd1a7f524bb95886eb956569ac38a23a784/PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440", size = 227419, upload-time = "2022-12-31T10:36:13.13Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/83/691bdb309306232362503083cb15777491045dd54f45393a317dc7d8082f/pypdf-6.9.2.tar.gz", hash = "sha256:7f850faf2b0d4ab936582c05da32c52214c2b089d61a316627b5bfb5b0dab46c", size = 5311837, upload-time = "2026-03-23T14:53:27.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/5e/c86a5643653825d3c913719e788e41386bee415c2b87b4f955432f2de6b2/pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928", size = 232572, upload-time = "2022-12-31T10:36:10.327Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7e/c85f41243086a8fe5d1baeba527cb26a1918158a565932b41e0f7c0b32e9/pypdf-6.9.2-py3-none-any.whl", hash = "sha256:662cf29bcb419a36a1365232449624ab40b7c2d0cfc28e54f42eeecd1fd7e844", size = 333744, upload-time = "2026-03-23T14:53:26.573Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- PyPDF2 has CVE-2026-33699 and no maintained.
- Replace all PyPDF2 imports with pypdf across 13+ platform modules
- pypdf is the maintained successor with compatible API