### PR TITLE
fix: convert published_date str to datetime in zenodo and hal connectors

### DIFF
--- a/paper_search_mcp/academic_platforms/hal.py
+++ b/paper_search_mcp/academic_platforms/hal.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import datetime
 from typing import List, Optional, Dict, Any
 
 import requests
@@ -239,9 +240,16 @@ class HALSearcher(PaperSource):
                 doi = doi[0] if doi else ""
 
             year = doc.get("publicationDateY_i") or doc.get("producedDateY_i", "")
-            pub_date = (
-                str(year) if year else (doc.get("submittedDate_s", "") or "")[:10]
-            )
+            pub_date_str = str(year) if year else (doc.get("submittedDate_s", "") or "")[:10]
+            pub_date = None
+            if pub_date_str:
+                try:
+                    pub_date = datetime.fromisoformat(pub_date_str[:10])
+                except ValueError:
+                    try:
+                        pub_date = datetime(int(pub_date_str[:4]), 1, 1)
+                    except (ValueError, TypeError):
+                        pub_date = None
 
             pdf_url = doc.get("fileMain_s", "") or ""
             record_url = doc.get("uri_s", f"https://hal.archives-ouvertes.fr/{hal_id}")
@@ -252,7 +260,7 @@ class HALSearcher(PaperSource):
                 authors=authors,
                 abstract=abstract.strip(),
                 doi=doi,
-                published_date=str(pub_date),
+                published_date=pub_date,
                 pdf_url=pdf_url,
                 url=record_url,
                 source="hal",

--- a/paper_search_mcp/academic_platforms/zenodo.py
+++ b/paper_search_mcp/academic_platforms/zenodo.py
@@ -10,6 +10,7 @@ API docs: https://developers.zenodo.org/
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import List, Optional, Dict, Any
 
 import requests
@@ -244,9 +245,13 @@ class ZenodoSearcher(PaperSource):
 
             abstract = re.sub(r"<[^>]+>", " ", abstract).strip()
 
-            pub_date = meta.get("publication_date", "")
-            if len(pub_date) >= 4:
-                pub_date = pub_date[:10]  # keep YYYY-MM-DD
+            pub_date_str = meta.get("publication_date", "")
+            pub_date = None
+            if len(pub_date_str) >= 4:
+                try:
+                    pub_date = datetime.fromisoformat(pub_date_str[:10])
+                except ValueError:
+                    pub_date = datetime(int(pub_date_str[:4]), 1, 1)
 
             # Pick the best available PDF url from top-level links
             pdf_url = ""


### PR DESCRIPTION
**Bug:** `search_zenodo` and `search_hal` raise `'str' object has no attribute 'isoformat'` when results are returned via `search_papers(sources="all")`.

**Root cause:** Both connectors assign a plain string to `Paper.published_date`, but `Paper.to_dict()` calls `.isoformat()` on it, which only works on `datetime` objects.

**Fix:** Import `datetime` in both files and parse the date string into a `datetime` object before constructing `Paper()`. Falls back to year-only or `None` if parsing fails.
error message:
"errors": {
        "zenodo": "'str' object has no attribute 'isoformat'",
        "hal": "'str' object has no attribute 'isoformat'"
   },