### PR TITLE
Fix Semantic Scholar parsing when publication date is missing

### DIFF
--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -41,8 +41,11 @@ class SemanticSearcher(PaperSource):
             }
         )
 
-    def _parse_date(self, date_str: str) -> Optional[datetime]:
+    def _parse_date(self, date_str: Optional[str]) -> Optional[datetime]:
         """Parse date from Semantic Scholar format (e.g., '2025-06-02')"""
+        if not date_str:
+            return None
+
         try:
             return datetime.strptime(date_str.strip(), "%Y-%m-%d")
         except ValueError:

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -45,6 +45,25 @@ class TestSemanticSearcher(unittest.TestCase):
             self.assertTrue(expected_path.exists())
             self.assertEqual(expected_path.read_bytes(), b"%PDF-1.4 test content")
 
+    def test_parse_paper_handles_missing_publication_date(self):
+        item = {
+            "paperId": "paper-123",
+            "title": "Paper without a publication date",
+            "authors": [{"name": "Ada Lovelace"}],
+            "abstract": "",
+            "url": "https://www.semanticscholar.org/paper/paper-123",
+            "publicationDate": None,
+            "externalIds": {},
+            "fieldsOfStudy": None,
+            "openAccessPdf": None,
+            "citationCount": 0,
+        }
+
+        paper = self.searcher._parse_paper(item)
+
+        self.assertIsNotNone(paper)
+        self.assertIsNone(paper.published_date)
+
     @unittest.skipUnless(check_semantic_accessible(), "Semantic Scholar not accessible")
     def test_search_basic(self):
         """Test basic search functionality"""


### PR DESCRIPTION
## Summary
- Handle `publicationDate: null` from Semantic Scholar without failing parsing.
- Preserve Semantic Scholar papers with missing publication dates by setting `published_date=None`.
- Add a regression test for missing Semantic Scholar publication dates.

## Why
Semantic Scholar can return `publicationDate` as `null`. The parser previously passed that value into `_parse_date()`, which called `.strip()` and caused:

`Failed to parse Semantic paper: 'NoneType' object has no attribute 'strip'`

This made otherwise valid papers get skipped during parsing.

## Changes
- Updated `SemanticSearcher._parse_date()` to return `None` for missing or empty date values.
- Added `test_parse_paper_handles_missing_publication_date` in `tests/test_semantic.py`.

## Testing
- `pytest tests/test_semantic.py -k "download_pdf_saves_file_when_pdf_url_available or missing_publication_date"`

Full suite not run; Semantic Scholar tests include live upstream calls that may be rate-limited or unavailable.