### PR TITLE
Harden Semantic Scholar PDF downloads

### DIFF
--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 from datetime import datetime
 import os
 import requests
@@ -11,6 +11,7 @@ from .base import PaperSource
 import logging
 from pypdf import PdfReader
 import re
+from xml.etree import ElementTree as ET
 from ..config import get_env
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,11 @@ class SemanticSearcher(PaperSource):
 
     SEMANTIC_SEARCH_URL = "https://api.semanticscholar.org/graph/v1/paper/search"
     SEMANTIC_BASE_URL = "https://api.semanticscholar.org/graph/v1"
+    EUROPE_PMC_PDF_URL = "https://europepmc.org/articles/{pmcid}?pdf=render"
+    PMC_PDF_URL = "https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/pdf/"
+    EUROPE_PMC_FULL_TEXT_XML_URL = (
+        "https://www.ebi.ac.uk/europepmc/webservices/rest/{pmcid}/fullTextXML"
+    )
     BROWSERS = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
@@ -100,8 +106,8 @@ class SemanticSearcher(PaperSource):
 
             # Safely get PDF URL - 支持从 disclaimer 中提取
             pdf_url = ""
-            if item.get("openAccessPdf"):
-                open_access_pdf = item["openAccessPdf"]
+            open_access_pdf = item.get("openAccessPdf") or {}
+            if open_access_pdf:
                 # 首先尝试直接获取 URL
                 if open_access_pdf.get("url"):
                     pdf_url = open_access_pdf["url"]
@@ -113,8 +119,9 @@ class SemanticSearcher(PaperSource):
 
             # Safely get DOI
             doi = ""
-            if item.get("externalIds") and item["externalIds"].get("DOI"):
-                doi = item["externalIds"]["DOI"]
+            external_ids = item.get("externalIds") or {}
+            if external_ids and external_ids.get("DOI"):
+                doi = external_ids["DOI"]
 
             if not doi and item.get("abstract"):
                 doi = extract_doi(item["abstract"])
@@ -136,6 +143,10 @@ class SemanticSearcher(PaperSource):
                 categories=categories,
                 doi=doi,
                 citations=item.get("citationCount", 0),
+                extra={
+                    "externalIds": external_ids,
+                    "openAccessPdf": open_access_pdf,
+                },
             )
 
         except Exception as e:
@@ -354,6 +365,180 @@ class SemanticSearcher(PaperSource):
 
         return papers[:max_results]
 
+    @staticmethod
+    def _clean_text(text: str) -> str:
+        return re.sub(r"\s+", " ", text).strip()
+
+    @staticmethod
+    def _local_name(tag: str) -> str:
+        return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+    @staticmethod
+    def _normalize_pmcid(value: object) -> str:
+        if value is None:
+            return ""
+
+        text = str(value).strip()
+        if not text:
+            return ""
+
+        pmcid_match = re.search(r"PMC\d+", text, flags=re.IGNORECASE)
+        if pmcid_match:
+            return pmcid_match.group(0).upper()
+
+        if re.fullmatch(r"\d+", text):
+            return f"PMC{text}"
+
+        return ""
+
+    @staticmethod
+    def _is_pmc_article_url(url: str) -> bool:
+        normalized_url = url.split("?", 1)[0].split("#", 1)[0].rstrip("/").lower()
+        return bool(re.search(r"/(?:pmc/)?articles/pmc\d+$", normalized_url))
+
+    @staticmethod
+    def _looks_like_html(content: bytes) -> bool:
+        prefix = content[:128].lstrip().lower()
+        return prefix.startswith((b"<!doctype", b"<html", b"<?xml"))
+
+    @classmethod
+    def _looks_like_pdf(cls, content: bytes, content_type: str = "") -> bool:
+        if not content:
+            return False
+
+        prefix = content[:1024].lstrip()
+        if prefix.startswith(b"%PDF"):
+            return True
+
+        content_type = content_type.lower()
+        return "pdf" in content_type and not cls._looks_like_html(content)
+
+    @classmethod
+    def _pdf_file_is_valid(cls, pdf_path: str) -> bool:
+        try:
+            with open(pdf_path, "rb") as file:
+                return cls._looks_like_pdf(file.read(1024))
+        except OSError:
+            return False
+
+    def _download_headers(self) -> Dict[str, str]:
+        return {
+            "User-Agent": self.session.headers.get(
+                "User-Agent", random.choice(self.BROWSERS)
+            ),
+            "Accept": "application/pdf,application/octet-stream;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+        }
+
+    def _extract_pmcids(self, paper: Paper) -> List[str]:
+        pmcids: List[str] = []
+
+        def add(value: object) -> None:
+            pmcid = self._normalize_pmcid(value)
+            if pmcid and pmcid not in pmcids:
+                pmcids.append(pmcid)
+
+        extra = getattr(paper, "extra", None) or {}
+        external_ids = extra.get("externalIds", {}) if isinstance(extra, dict) else {}
+        if isinstance(external_ids, dict):
+            add(external_ids.get("PubMedCentral"))
+            add(external_ids.get("PMCID"))
+
+        for text in (getattr(paper, "pdf_url", ""), getattr(paper, "url", "")):
+            if not text:
+                continue
+            for match in re.findall(r"PMC\d+", text, flags=re.IGNORECASE):
+                add(match)
+
+        return pmcids
+
+    def _candidate_pdf_urls(self, paper: Paper) -> List[str]:
+        candidates: List[str] = []
+        seen = set()
+
+        def add(url: str) -> None:
+            url = (url or "").strip()
+            if url and url not in seen:
+                seen.add(url)
+                candidates.append(url)
+
+        semantic_pdf_url = getattr(paper, "pdf_url", "")
+        if semantic_pdf_url and not self._is_pmc_article_url(semantic_pdf_url):
+            add(semantic_pdf_url)
+
+        for pmcid in self._extract_pmcids(paper):
+            add(self.EUROPE_PMC_PDF_URL.format(pmcid=pmcid))
+            add(self.PMC_PDF_URL.format(pmcid=pmcid))
+
+        if semantic_pdf_url and self._is_pmc_article_url(semantic_pdf_url):
+            add(semantic_pdf_url)
+
+        return candidates
+
+    def _download_pdf_url(self, pdf_url: str, pdf_path: str) -> None:
+        response = requests.get(
+            pdf_url,
+            headers=self._download_headers(),
+            timeout=60,
+            allow_redirects=True,
+        )
+        response.raise_for_status()
+
+        content_type = response.headers.get("Content-Type", "")
+        if not self._looks_like_pdf(response.content, content_type):
+            first_bytes = response.content[:16]
+            raise ValueError(
+                "URL did not return a PDF "
+                f"(content-type={content_type or 'unknown'}, "
+                f"final_url={response.url}, first_bytes={first_bytes!r})"
+            )
+
+        with open(pdf_path, "wb") as file:
+            file.write(response.content)
+
+    def _download_paper_pdf(
+        self, paper_id: str, save_path: str
+    ) -> Tuple[Optional[str], Optional[Paper], List[str]]:
+        paper = self.get_paper_details(paper_id)
+        if not paper:
+            return None, None, [f"Could not find paper details for {paper_id}"]
+
+        os.makedirs(save_path, exist_ok=True)
+        filename = f"semantic_{paper_id.replace('/', '_')}.pdf"
+        pdf_path = os.path.join(save_path, filename)
+
+        if os.path.exists(pdf_path):
+            if self._pdf_file_is_valid(pdf_path):
+                return pdf_path, paper, []
+            try:
+                os.remove(pdf_path)
+            except OSError as exc:
+                return None, paper, [f"Could not remove invalid cached PDF: {exc}"]
+
+        candidates = self._candidate_pdf_urls(paper)
+        if not candidates:
+            return None, paper, [f"Could not find PDF URL for paper {paper_id}"]
+
+        errors: List[str] = []
+        for pdf_url in candidates:
+            try:
+                self._download_pdf_url(pdf_url, pdf_path)
+                return pdf_path, paper, errors
+            except Exception as exc:
+                errors.append(f"{pdf_url}: {exc}")
+                if os.path.exists(pdf_path) and not self._pdf_file_is_valid(pdf_path):
+                    try:
+                        os.remove(pdf_path)
+                    except OSError:
+                        pass
+
+        return None, paper, errors
+
+    @staticmethod
+    def _format_download_error(paper_id: str, errors: List[str]) -> str:
+        details = "; ".join(errors) if errors else "No downloadable PDF found"
+        return f"Error downloading PDF for {paper_id}: {details}"
+
     def download_pdf(self, paper_id: str, save_path: str) -> str:
         """
         Download PDF from Semantic Scholar
@@ -374,25 +559,131 @@ class SemanticSearcher(PaperSource):
             str: Path to downloaded file or error message
         """
         try:
-            paper = self.get_paper_details(paper_id)
-            if not paper or not paper.pdf_url:
-                return f"Error: Could not find PDF URL for paper {paper_id}"
-            pdf_url = paper.pdf_url
-            pdf_response = requests.get(pdf_url, timeout=30)
-            pdf_response.raise_for_status()
-
-            # Create download directory if it doesn't exist
-            os.makedirs(save_path, exist_ok=True)
-
-            filename = f"semantic_{paper_id.replace('/', '_')}.pdf"
-            pdf_path = os.path.join(save_path, filename)
-
-            with open(pdf_path, "wb") as f:
-                f.write(pdf_response.content)
-            return pdf_path
+            pdf_path, _paper, errors = self._download_paper_pdf(paper_id, save_path)
+            if pdf_path:
+                return pdf_path
+            return self._format_download_error(paper_id, errors)
         except Exception as e:
             logger.error(f"PDF download error: {e}")
             return f"Error downloading PDF: {e}"
+
+    def _extract_pdf_text(self, pdf_path: str) -> str:
+        reader = PdfReader(pdf_path)
+        text = ""
+
+        for page_num, page in enumerate(reader.pages):
+            try:
+                page_text = page.extract_text()
+                if page_text:
+                    text += f"\n--- Page {page_num + 1} ---\n"
+                    text += page_text + "\n"
+            except Exception as e:
+                logger.warning(
+                    f"Failed to extract text from page {page_num + 1}: {e}"
+                )
+                continue
+
+        return text.strip()
+
+    def _format_read_metadata(
+        self,
+        paper: Optional[Paper],
+        paper_id: str,
+        pdf_path: str = "",
+        full_text_source: str = "",
+    ) -> str:
+        metadata = f"Title: {paper.title if paper else paper_id}\n"
+        metadata += f"Authors: {', '.join(paper.authors) if paper else ''}\n"
+        metadata += f"Published Date: {paper.published_date if paper else ''}\n"
+        metadata += f"URL: {paper.url if paper else ''}\n"
+        if pdf_path:
+            metadata += f"PDF downloaded to: {pdf_path}\n"
+        if full_text_source:
+            metadata += f"Full text source: {full_text_source}\n"
+        metadata += "=" * 80 + "\n\n"
+        return metadata
+
+    def _element_text(self, element: ET.Element) -> str:
+        return self._clean_text(" ".join(element.itertext()))
+
+    def _find_first_element(
+        self, root: ET.Element, tag_name: str
+    ) -> Optional[ET.Element]:
+        for element in root.iter():
+            if self._local_name(element.tag) == tag_name:
+                return element
+        return None
+
+    def _collect_body_text(self, element: ET.Element, parts: List[str]) -> None:
+        for child in list(element):
+            tag_name = self._local_name(child.tag)
+            if tag_name in {"title", "p"}:
+                text = self._element_text(child)
+                if text:
+                    parts.append(text)
+            elif tag_name in {"sec", "body"}:
+                self._collect_body_text(child, parts)
+
+    def _extract_text_from_article_xml(self, xml_content: bytes) -> str:
+        root = ET.fromstring(xml_content)
+        parts: List[str] = []
+
+        title = self._find_first_element(root, "article-title")
+        if title is not None:
+            title_text = self._element_text(title)
+            if title_text:
+                parts.append(title_text)
+
+        for abstract in root.iter():
+            if self._local_name(abstract.tag) == "abstract":
+                abstract_text = self._element_text(abstract)
+                if abstract_text:
+                    parts.append(abstract_text)
+
+        body = self._find_first_element(root, "body")
+        if body is not None:
+            self._collect_body_text(body, parts)
+
+        deduped_parts: List[str] = []
+        seen = set()
+        for part in parts:
+            if part not in seen:
+                seen.add(part)
+                deduped_parts.append(part)
+
+        return "\n\n".join(deduped_parts)
+
+    def _read_europe_pmc_full_text(
+        self, paper: Optional[Paper]
+    ) -> Tuple[str, str]:
+        if not paper:
+            return "", ""
+
+        for pmcid in self._extract_pmcids(paper):
+            full_text_url = self.EUROPE_PMC_FULL_TEXT_XML_URL.format(pmcid=pmcid)
+            try:
+                response = requests.get(
+                    full_text_url,
+                    headers={
+                        "User-Agent": self.session.headers.get(
+                            "User-Agent", random.choice(self.BROWSERS)
+                        ),
+                        "Accept": "application/xml,text/xml;q=0.9,*/*;q=0.8",
+                    },
+                    timeout=60,
+                )
+                response.raise_for_status()
+                text = self._extract_text_from_article_xml(response.content)
+                if text:
+                    return text, full_text_url
+            except Exception as exc:
+                logger.warning(
+                    "Europe PMC full-text fallback failed for %s: %s",
+                    pmcid,
+                    exc,
+                )
+
+        return "", ""
 
     def read_paper(self, paper_id: str, save_path: str = "./downloads") -> str:
         """
@@ -414,53 +705,54 @@ class SemanticSearcher(PaperSource):
             str: Extracted text from the PDF or error message
         """
         try:
-            os.makedirs(save_path, exist_ok=True)
-            filename = f"semantic_{paper_id.replace('/', '_')}.pdf"
-            pdf_path = os.path.join(save_path, filename)
-
-            if not os.path.exists(pdf_path):
-                paper = self.get_paper_details(paper_id)
-                if not paper or not paper.pdf_url:
-                    return f"Error: Could not find PDF URL for paper {paper_id}"
-
-                pdf_response = requests.get(paper.pdf_url, timeout=30)
-                pdf_response.raise_for_status()
-
-                with open(pdf_path, "wb") as f:
-                    f.write(pdf_response.content)
-            else:
-                paper = self.get_paper_details(paper_id)
-
-            # Extract text using PyPDF
-            reader = PdfReader(pdf_path)
-            text = ""
-
-            for page_num, page in enumerate(reader.pages):
-                try:
-                    page_text = page.extract_text()
-                    if page_text:
-                        text += f"\n--- Page {page_num + 1} ---\n"
-                        text += page_text + "\n"
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to extract text from page {page_num + 1}: {e}"
+            pdf_path, paper, errors = self._download_paper_pdf(paper_id, save_path)
+            if not pdf_path:
+                full_text, full_text_source = self._read_europe_pmc_full_text(paper)
+                if full_text:
+                    return (
+                        self._format_read_metadata(
+                            paper,
+                            paper_id,
+                            full_text_source=full_text_source,
+                        )
+                        + full_text
                     )
-                    continue
+                return self._format_download_error(paper_id, errors)
 
-            if not text.strip():
+            try:
+                text = self._extract_pdf_text(pdf_path)
+            except Exception as exc:
+                logger.warning("PDF text extraction failed for %s: %s", pdf_path, exc)
+                full_text, full_text_source = self._read_europe_pmc_full_text(paper)
+                if full_text:
+                    return (
+                        self._format_read_metadata(
+                            paper,
+                            paper_id,
+                            pdf_path=pdf_path,
+                            full_text_source=full_text_source,
+                        )
+                        + full_text
+                    )
+                return f"PDF downloaded to {pdf_path}, but text extraction failed: {exc}"
+
+            if not text:
+                full_text, full_text_source = self._read_europe_pmc_full_text(paper)
+                if full_text:
+                    return (
+                        self._format_read_metadata(
+                            paper,
+                            paper_id,
+                            pdf_path=pdf_path,
+                            full_text_source=full_text_source,
+                        )
+                        + full_text
+                    )
                 return (
                     f"PDF downloaded to {pdf_path}, but unable to extract readable text"
                 )
 
-            # Add paper metadata at the beginning
-            metadata = f"Title: {paper.title if paper else paper_id}\n"
-            metadata += f"Authors: {', '.join(paper.authors) if paper else ''}\n"
-            metadata += f"Published Date: {paper.published_date if paper else ''}\n"
-            metadata += f"URL: {paper.url if paper else ''}\n"
-            metadata += f"PDF downloaded to: {pdf_path}\n"
-            metadata += "=" * 80 + "\n\n"
-
-            return metadata + text.strip()
+            return self._format_read_metadata(paper, paper_id, pdf_path=pdf_path) + text
 
         except requests.RequestException as e:
             logger.error(f"Error downloading PDF: {e}")

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -476,7 +476,7 @@ class SemanticSearcher(PaperSource):
         return candidates
 
     def _download_pdf_url(self, pdf_url: str, pdf_path: str) -> None:
-        response = requests.get(
+        response = self.session.get(
             pdf_url,
             headers=self._download_headers(),
             timeout=60,
@@ -662,7 +662,7 @@ class SemanticSearcher(PaperSource):
         for pmcid in self._extract_pmcids(paper):
             full_text_url = self.EUROPE_PMC_FULL_TEXT_XML_URL.format(pmcid=pmcid)
             try:
-                response = requests.get(
+                response = self.session.get(
                     full_text_url,
                     headers={
                         "User-Agent": self.session.headers.get(

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -168,7 +168,8 @@ class SemanticSearcher(PaperSource):
         api_key = get_env("SEMANTIC_SCHOLAR_API_KEY", "")
         if not api_key or api_key.strip() == "":
             logger.warning(
-                "No SEMANTIC_SCHOLAR_API_KEY set or it's empty. Using unauthenticated access with lower rate limits."
+                "No SEMANTIC_SCHOLAR_API_KEY set or it's empty. "
+                "Using unauthenticated access with lower rate limits."
             )
             return None
         return api_key.strip()
@@ -212,13 +213,18 @@ class SemanticSearcher(PaperSource):
                             else retry_delay * (2**attempt)
                         )
                         logger.warning(
-                            f"Rate limited (429). Waiting {wait_time} seconds before retry {attempt + 1}/{max_retries}"
+                            "Rate limited (429). Waiting %s seconds before retry %s/%s",
+                            wait_time,
+                            attempt + 1,
+                            max_retries,
                         )
                         time.sleep(wait_time)
                         continue
                     else:
                         logger.error(
-                            f"Rate limited (429) after {max_retries} attempts. Please wait before making more requests."
+                            "Rate limited (429) after %s attempts. "
+                            "Please wait before making more requests.",
+                            max_retries,
                         )
                         return {
                             "error": "rate_limited",
@@ -250,13 +256,18 @@ class SemanticSearcher(PaperSource):
                             else retry_delay * (2**attempt)
                         )
                         logger.warning(
-                            f"Rate limited (429). Waiting {wait_time} seconds before retry {attempt + 1}/{max_retries}"
+                            "Rate limited (429). Waiting %s seconds before retry %s/%s",
+                            wait_time,
+                            attempt + 1,
+                            max_retries,
                         )
                         time.sleep(wait_time)
                         continue
                     else:
                         logger.error(
-                            f"Rate limited (429) after {max_retries} attempts. Please wait before making more requests."
+                            "Rate limited (429) after %s attempts. "
+                            "Please wait before making more requests.",
+                            max_retries,
                         )
                         return {
                             "error": "rate_limited",
@@ -517,10 +528,10 @@ class SemanticSearcher(PaperSource):
                 if chunk:
                     initial_chunks.append(chunk)
                     initial_content += chunk
-                    if (
+                    header_scan_complete = (
                         len(initial_content) >= self.PDF_HEADER_SCAN_BYTES
-                        or self._looks_like_pdf(initial_content)
-                    ):
+                    )
+                    if header_scan_complete or self._looks_like_pdf(initial_content):
                         break
 
             if not self._looks_like_pdf(initial_content):
@@ -618,9 +629,11 @@ class SemanticSearcher(PaperSource):
                 return pdf_path, None, []
             remove_error = self._remove_pdf_file(pdf_path, "cache validation failed")
             if remove_error:
-                return None, None, [
-                    f"Could not remove invalid cached PDF: {remove_error}"
-                ]
+                return (
+                    None,
+                    None,
+                    [f"Could not remove invalid cached PDF: {remove_error}"],
+                )
 
         paper = self.get_paper_details(paper_id)
         if not paper:
@@ -686,9 +699,7 @@ class SemanticSearcher(PaperSource):
                     text += f"\n--- Page {page_num + 1} ---\n"
                     text += page_text + "\n"
             except Exception as e:
-                logger.warning(
-                    f"Failed to extract text from page {page_num + 1}: {e}"
-                )
+                logger.warning(f"Failed to extract text from page {page_num + 1}: {e}")
                 continue
 
         return text.strip()
@@ -742,9 +753,7 @@ class SemanticSearcher(PaperSource):
         try:
             return DefusedElementTree.fromstring(xml_content)
         except DefusedXmlException as exc:
-            raise ValueError(
-                "Unsafe XML declaration in Europe PMC full text"
-            ) from exc
+            raise ValueError("Unsafe XML declaration in Europe PMC full text") from exc
 
     def _extract_text_from_article_xml(self, xml_content: bytes) -> str:
         root = self._parse_article_xml(xml_content)
@@ -775,9 +784,7 @@ class SemanticSearcher(PaperSource):
 
         return "\n\n".join(deduped_parts)
 
-    def _read_europe_pmc_full_text(
-        self, paper: Optional[Paper]
-    ) -> Tuple[str, str]:
+    def _read_europe_pmc_full_text(self, paper: Optional[Paper]) -> Tuple[str, str]:
         if not paper:
             return "", ""
 
@@ -853,8 +860,8 @@ class SemanticSearcher(PaperSource):
             except Exception as exc:
                 logger.warning("PDF text extraction failed for %s: %s", pdf_path, exc)
                 remove_error = self._remove_pdf_file(pdf_path, "text extraction failed")
-                cached_pdf_removed = (
-                    remove_error is None and not os.path.exists(pdf_path)
+                cached_pdf_removed = remove_error is None and not os.path.exists(
+                    pdf_path
                 )
                 full_text, full_text_source = self._read_europe_pmc_full_text(paper)
                 if full_text:

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -2,7 +2,6 @@ from typing import Dict, List, Optional, Tuple
 from datetime import datetime
 import os
 import requests
-from bs4 import BeautifulSoup
 import time
 import random
 import tempfile

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -476,35 +476,40 @@ class SemanticSearcher(PaperSource):
         return candidates
 
     def _download_pdf_url(self, pdf_url: str, pdf_path: str) -> None:
-        response = self.session.get(
-            pdf_url,
-            headers=self._download_headers(),
-            stream=True,
-            timeout=60,
-            allow_redirects=True,
-        )
-        response.raise_for_status()
-
-        content_type = response.headers.get("Content-Type", "")
-        chunks = response.iter_content(chunk_size=8192)
-        first_chunk = b""
-        for chunk in chunks:
-            if chunk:
-                first_chunk = chunk
-                break
-        if not self._looks_like_pdf(first_chunk, content_type):
-            first_bytes = first_chunk[:16]
-            raise ValueError(
-                "URL did not return a PDF "
-                f"(content-type={content_type or 'unknown'}, "
-                f"final_url={response.url}, first_bytes={first_bytes!r})"
+        response = None
+        try:
+            response = self.session.get(
+                pdf_url,
+                headers=self._download_headers(),
+                stream=True,
+                timeout=60,
+                allow_redirects=True,
             )
+            response.raise_for_status()
 
-        with open(pdf_path, "wb") as file:
-            file.write(first_chunk)
+            content_type = response.headers.get("Content-Type", "")
+            chunks = response.iter_content(chunk_size=8192)
+            first_chunk = b""
             for chunk in chunks:
                 if chunk:
-                    file.write(chunk)
+                    first_chunk = chunk
+                    break
+            if not self._looks_like_pdf(first_chunk, content_type):
+                first_bytes = first_chunk[:16]
+                raise ValueError(
+                    "URL did not return a PDF "
+                    f"(content-type={content_type or 'unknown'}, "
+                    f"final_url={response.url}, first_bytes={first_bytes!r})"
+                )
+
+            with open(pdf_path, "wb") as file:
+                file.write(first_chunk)
+                for chunk in chunks:
+                    if chunk:
+                        file.write(chunk)
+        finally:
+            if response is not None:
+                response.close()
 
     @staticmethod
     def _safe_paper_id(paper_id: str) -> str:
@@ -738,6 +743,14 @@ class SemanticSearcher(PaperSource):
                 text = self._extract_pdf_text(pdf_path)
             except Exception as exc:
                 logger.warning("PDF text extraction failed for %s: %s", pdf_path, exc)
+                try:
+                    os.remove(pdf_path)
+                except OSError as remove_exc:
+                    logger.warning(
+                        "Could not remove PDF after extraction failure for %s: %s",
+                        pdf_path,
+                        remove_exc,
+                    )
                 full_text, full_text_source = self._read_europe_pmc_full_text(paper)
                 if full_text:
                     return (

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -479,14 +479,21 @@ class SemanticSearcher(PaperSource):
         response = self.session.get(
             pdf_url,
             headers=self._download_headers(),
+            stream=True,
             timeout=60,
             allow_redirects=True,
         )
         response.raise_for_status()
 
         content_type = response.headers.get("Content-Type", "")
-        if not self._looks_like_pdf(response.content, content_type):
-            first_bytes = response.content[:16]
+        chunks = response.iter_content(chunk_size=8192)
+        first_chunk = b""
+        for chunk in chunks:
+            if chunk:
+                first_chunk = chunk
+                break
+        if not self._looks_like_pdf(first_chunk, content_type):
+            first_bytes = first_chunk[:16]
             raise ValueError(
                 "URL did not return a PDF "
                 f"(content-type={content_type or 'unknown'}, "
@@ -494,7 +501,15 @@ class SemanticSearcher(PaperSource):
             )
 
         with open(pdf_path, "wb") as file:
-            file.write(response.content)
+            file.write(first_chunk)
+            for chunk in chunks:
+                if chunk:
+                    file.write(chunk)
+
+    @staticmethod
+    def _safe_paper_id(paper_id: str) -> str:
+        safe_id = re.sub(r"[^a-zA-Z0-9._-]+", "_", paper_id).strip("._")
+        return safe_id or "paper"
 
     def _download_paper_pdf(
         self, paper_id: str, save_path: str
@@ -504,7 +519,7 @@ class SemanticSearcher(PaperSource):
             return None, None, [f"Could not find paper details for {paper_id}"]
 
         os.makedirs(save_path, exist_ok=True)
-        filename = f"semantic_{paper_id.replace('/', '_')}.pdf"
+        filename = f"semantic_{self._safe_paper_id(paper_id)}.pdf"
         pdf_path = os.path.join(save_path, filename)
 
         if os.path.exists(pdf_path):
@@ -565,7 +580,7 @@ class SemanticSearcher(PaperSource):
             return self._format_download_error(paper_id, errors)
         except Exception as e:
             logger.error(f"PDF download error: {e}")
-            return f"Error downloading PDF: {e}"
+            return self._format_download_error(paper_id, [str(e)])
 
     def _extract_pdf_text(self, pdf_path: str) -> str:
         reader = PdfReader(pdf_path)

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Optional, Tuple
 from datetime import datetime
+import hashlib
 import os
 import requests
 import time
@@ -29,6 +30,7 @@ class SemanticSearcher(PaperSource):
     )
     DOWNLOAD_CHUNK_SIZE = 8192
     PDF_HEADER_SCAN_BYTES = 1024
+    SAFE_PAPER_ID_MAX_LENGTH = 120
     BROWSERS = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
@@ -575,10 +577,19 @@ class SemanticSearcher(PaperSource):
                         "Could not remove partial PDF download: %s", temp_path
                     )
 
-    @staticmethod
-    def _safe_paper_id(paper_id: str) -> str:
+    @classmethod
+    def _safe_paper_id(cls, paper_id: str) -> str:
         safe_id = re.sub(r"[^a-zA-Z0-9._-]+", "_", paper_id).strip("._")
-        return safe_id or "paper"
+        if not safe_id:
+            return "paper"
+
+        if len(safe_id) <= cls.SAFE_PAPER_ID_MAX_LENGTH:
+            return safe_id
+
+        digest = hashlib.sha256(paper_id.encode("utf-8")).hexdigest()[:12]
+        prefix_length = cls.SAFE_PAPER_ID_MAX_LENGTH - len(digest) - 1
+        prefix = safe_id[:prefix_length].rstrip("._-") or "paper"
+        return f"{prefix}_{digest}"
 
     @staticmethod
     def _remove_pdf_file(pdf_path: str, reason: str) -> Optional[str]:
@@ -596,22 +607,22 @@ class SemanticSearcher(PaperSource):
     def _download_paper_pdf(
         self, paper_id: str, save_path: str
     ) -> Tuple[Optional[str], Optional[Paper], List[str]]:
-        paper = self.get_paper_details(paper_id)
-        if not paper:
-            return None, None, [f"Could not find paper details for {paper_id}"]
-
         os.makedirs(save_path, exist_ok=True)
         filename = f"semantic_{self._safe_paper_id(paper_id)}.pdf"
         pdf_path = os.path.join(save_path, filename)
 
         if os.path.exists(pdf_path):
             if self._pdf_file_is_valid(pdf_path):
-                return pdf_path, paper, []
+                return pdf_path, None, []
             remove_error = self._remove_pdf_file(pdf_path, "cache validation failed")
             if remove_error:
-                return None, paper, [
+                return None, None, [
                     f"Could not remove invalid cached PDF: {remove_error}"
                 ]
+
+        paper = self.get_paper_details(paper_id)
+        if not paper:
+            return None, None, [f"Could not find paper details for {paper_id}"]
 
         candidates = self._candidate_pdf_urls(paper)
         if not candidates:
@@ -724,8 +735,15 @@ class SemanticSearcher(PaperSource):
             elif tag_name in {"sec", "body"}:
                 self._collect_body_text(child, parts)
 
+    @staticmethod
+    def _parse_article_xml(xml_content: bytes) -> ET.Element:
+        if re.search(br"<!\s*(?:doctype|entity)\b", xml_content, flags=re.IGNORECASE):
+            raise ValueError("Unsafe XML declaration in Europe PMC full text")
+
+        return ET.fromstring(xml_content, parser=ET.XMLParser())
+
     def _extract_text_from_article_xml(self, xml_content: bytes) -> str:
-        root = ET.fromstring(xml_content)
+        root = self._parse_article_xml(xml_content)
         parts: List[str] = []
 
         title = self._find_first_element(root, "article-title")

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -5,6 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 import time
 import random
+import tempfile
 from ..paper import Paper
 from ..utils import extract_doi
 from .base import PaperSource
@@ -27,6 +28,8 @@ class SemanticSearcher(PaperSource):
     EUROPE_PMC_FULL_TEXT_XML_URL = (
         "https://www.ebi.ac.uk/europepmc/webservices/rest/{pmcid}/fullTextXML"
     )
+    DOWNLOAD_CHUNK_SIZE = 8192
+    PDF_HEADER_SCAN_BYTES = 1024
     BROWSERS = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
@@ -402,24 +405,38 @@ class SemanticSearcher(PaperSource):
         return prefix.startswith((b"<!doctype", b"<html", b"<?xml"))
 
     @classmethod
-    def _looks_like_pdf(cls, content: bytes, content_type: str = "") -> bool:
+    def _looks_like_pdf(cls, content: bytes) -> bool:
         if not content:
             return False
 
-        prefix = content[:1024].lstrip()
-        if prefix.startswith(b"%PDF"):
-            return True
+        prefix = content[: cls.PDF_HEADER_SCAN_BYTES]
+        if cls._looks_like_html(prefix):
+            return False
 
-        content_type = content_type.lower()
-        return "pdf" in content_type and not cls._looks_like_html(content)
+        return prefix.lstrip().startswith(b"%PDF")
 
     @classmethod
     def _pdf_file_is_valid(cls, pdf_path: str) -> bool:
         try:
             with open(pdf_path, "rb") as file:
-                return cls._looks_like_pdf(file.read(1024))
+                return cls._looks_like_pdf(file.read(cls.PDF_HEADER_SCAN_BYTES))
         except OSError:
             return False
+
+    @staticmethod
+    def _response_content_length(headers: Dict[str, str]) -> Optional[int]:
+        content_encoding = headers.get("Content-Encoding", "").lower()
+        if content_encoding and content_encoding != "identity":
+            return None
+
+        content_length = headers.get("Content-Length")
+        if not content_length:
+            return None
+
+        try:
+            return int(content_length)
+        except ValueError:
+            return None
 
     def _download_headers(self) -> Dict[str, str]:
         return {
@@ -477,6 +494,7 @@ class SemanticSearcher(PaperSource):
 
     def _download_pdf_url(self, pdf_url: str, pdf_path: str) -> None:
         response = None
+        temp_path = ""
         try:
             response = self.session.get(
                 pdf_url,
@@ -488,33 +506,93 @@ class SemanticSearcher(PaperSource):
             response.raise_for_status()
 
             content_type = response.headers.get("Content-Type", "")
-            chunks = response.iter_content(chunk_size=8192)
-            first_chunk = b""
+            chunks = response.iter_content(chunk_size=self.DOWNLOAD_CHUNK_SIZE)
+            initial_chunks: List[bytes] = []
+            initial_content = b""
+
             for chunk in chunks:
                 if chunk:
-                    first_chunk = chunk
-                    break
-            if not self._looks_like_pdf(first_chunk, content_type):
-                first_bytes = first_chunk[:16]
+                    initial_chunks.append(chunk)
+                    initial_content += chunk
+                    if (
+                        len(initial_content) >= self.PDF_HEADER_SCAN_BYTES
+                        or self._looks_like_pdf(initial_content)
+                    ):
+                        break
+
+            if not self._looks_like_pdf(initial_content):
+                first_bytes = initial_content[:16]
                 raise ValueError(
                     "URL did not return a PDF "
                     f"(content-type={content_type or 'unknown'}, "
-                    f"final_url={response.url}, first_bytes={first_bytes!r})"
+                    f"final_url={getattr(response, 'url', pdf_url)}, "
+                    f"first_bytes={first_bytes!r})"
                 )
 
-            with open(pdf_path, "wb") as file:
-                file.write(first_chunk)
+            expected_size = self._response_content_length(response.headers)
+            target_dir = os.path.dirname(pdf_path) or "."
+            temp_file = tempfile.NamedTemporaryFile(
+                "wb",
+                delete=False,
+                dir=target_dir,
+                prefix=f".{os.path.basename(pdf_path)}.",
+                suffix=".tmp",
+            )
+            temp_path = temp_file.name
+
+            bytes_written = 0
+            with temp_file as file:
+                for chunk in initial_chunks:
+                    file.write(chunk)
+                    bytes_written += len(chunk)
                 for chunk in chunks:
                     if chunk:
                         file.write(chunk)
+                        bytes_written += len(chunk)
+
+            if expected_size is not None and bytes_written != expected_size:
+                raise ValueError(
+                    "Downloaded PDF size mismatch "
+                    f"(expected={expected_size}, actual={bytes_written}, "
+                    f"final_url={getattr(response, 'url', pdf_url)})"
+                )
+
+            if not self._pdf_file_is_valid(temp_path):
+                raise ValueError(
+                    f"Downloaded file failed PDF validation "
+                    f"(final_url={getattr(response, 'url', pdf_url)})"
+                )
+
+            os.replace(temp_path, pdf_path)
+            temp_path = ""
         finally:
             if response is not None:
                 response.close()
+            if temp_path and os.path.exists(temp_path):
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    logger.warning(
+                        "Could not remove partial PDF download: %s", temp_path
+                    )
 
     @staticmethod
     def _safe_paper_id(paper_id: str) -> str:
         safe_id = re.sub(r"[^a-zA-Z0-9._-]+", "_", paper_id).strip("._")
         return safe_id or "paper"
+
+    @staticmethod
+    def _remove_pdf_file(pdf_path: str, reason: str) -> Optional[str]:
+        try:
+            os.remove(pdf_path)
+            return None
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            logger.warning(
+                "Could not remove PDF %s after %s: %s", pdf_path, reason, exc
+            )
+            return str(exc)
 
     def _download_paper_pdf(
         self, paper_id: str, save_path: str
@@ -530,10 +608,11 @@ class SemanticSearcher(PaperSource):
         if os.path.exists(pdf_path):
             if self._pdf_file_is_valid(pdf_path):
                 return pdf_path, paper, []
-            try:
-                os.remove(pdf_path)
-            except OSError as exc:
-                return None, paper, [f"Could not remove invalid cached PDF: {exc}"]
+            remove_error = self._remove_pdf_file(pdf_path, "cache validation failed")
+            if remove_error:
+                return None, paper, [
+                    f"Could not remove invalid cached PDF: {remove_error}"
+                ]
 
         candidates = self._candidate_pdf_urls(paper)
         if not candidates:
@@ -547,10 +626,7 @@ class SemanticSearcher(PaperSource):
             except Exception as exc:
                 errors.append(f"{pdf_url}: {exc}")
                 if os.path.exists(pdf_path) and not self._pdf_file_is_valid(pdf_path):
-                    try:
-                        os.remove(pdf_path)
-                    except OSError:
-                        pass
+                    self._remove_pdf_file(pdf_path, "download validation failed")
 
         return None, paper, errors
 
@@ -612,10 +688,15 @@ class SemanticSearcher(PaperSource):
         pdf_path: str = "",
         full_text_source: str = "",
     ) -> str:
-        metadata = f"Title: {paper.title if paper else paper_id}\n"
-        metadata += f"Authors: {', '.join(paper.authors) if paper else ''}\n"
-        metadata += f"Published Date: {paper.published_date if paper else ''}\n"
-        metadata += f"URL: {paper.url if paper else ''}\n"
+        title = getattr(paper, "title", paper_id) if paper else paper_id
+        authors = getattr(paper, "authors", []) if paper else []
+        published_date = getattr(paper, "published_date", "") if paper else ""
+        url = getattr(paper, "url", "") if paper else ""
+
+        metadata = f"Title: {title}\n"
+        metadata += f"Authors: {', '.join(authors) if authors else ''}\n"
+        metadata += f"Published Date: {published_date or ''}\n"
+        metadata += f"URL: {url}\n"
         if pdf_path:
             metadata += f"PDF downloaded to: {pdf_path}\n"
         if full_text_source:
@@ -681,6 +762,7 @@ class SemanticSearcher(PaperSource):
 
         for pmcid in self._extract_pmcids(paper):
             full_text_url = self.EUROPE_PMC_FULL_TEXT_XML_URL.format(pmcid=pmcid)
+            response = None
             try:
                 response = self.session.get(
                     full_text_url,
@@ -702,6 +784,9 @@ class SemanticSearcher(PaperSource):
                     pmcid,
                     exc,
                 )
+            finally:
+                if response is not None:
+                    response.close()
 
         return "", ""
 
@@ -743,26 +828,30 @@ class SemanticSearcher(PaperSource):
                 text = self._extract_pdf_text(pdf_path)
             except Exception as exc:
                 logger.warning("PDF text extraction failed for %s: %s", pdf_path, exc)
-                try:
-                    os.remove(pdf_path)
-                except OSError as remove_exc:
-                    logger.warning(
-                        "Could not remove PDF after extraction failure for %s: %s",
-                        pdf_path,
-                        remove_exc,
-                    )
+                remove_error = self._remove_pdf_file(pdf_path, "text extraction failed")
+                cached_pdf_removed = (
+                    remove_error is None and not os.path.exists(pdf_path)
+                )
                 full_text, full_text_source = self._read_europe_pmc_full_text(paper)
                 if full_text:
                     return (
                         self._format_read_metadata(
                             paper,
                             paper_id,
-                            pdf_path=pdf_path,
+                            pdf_path="" if cached_pdf_removed else pdf_path,
                             full_text_source=full_text_source,
                         )
                         + full_text
                     )
-                return f"PDF downloaded to {pdf_path}, but text extraction failed: {exc}"
+                if cached_pdf_removed:
+                    return (
+                        f"PDF text extraction failed for {pdf_path}; "
+                        f"cached PDF was removed: {exc}"
+                    )
+                return (
+                    f"PDF downloaded to {pdf_path}, but text extraction failed "
+                    f"and the cached PDF could not be removed: {exc}"
+                )
 
             if not text:
                 full_text, full_text_source = self._read_europe_pmc_full_text(paper)
@@ -784,10 +873,10 @@ class SemanticSearcher(PaperSource):
 
         except requests.RequestException as e:
             logger.error(f"Error downloading PDF: {e}")
-            return f"Error downloading PDF: {e}"
+            return self._format_download_error(paper_id, [str(e)])
         except Exception as e:
             logger.error(f"Read paper error: {e}")
-            return f"Error reading paper: {e}"
+            return f"Error reading paper {paper_id}: {e}"
 
     def get_paper_details(self, paper_id: str) -> Optional[Paper]:
         """

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -845,6 +845,9 @@ class SemanticSearcher(PaperSource):
                     )
                 return self._format_download_error(paper_id, errors)
 
+            if paper is None:
+                paper = self.get_paper_details(paper_id)
+
             try:
                 text = self._extract_pdf_text(pdf_path)
             except Exception as exc:

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -874,7 +874,8 @@ class SemanticSearcher(PaperSource):
                     )
                 return (
                     f"PDF downloaded to {pdf_path}, but text extraction failed "
-                    f"and the cached PDF could not be removed: {exc}"
+                    f"and the cached PDF could not be removed "
+                    f"({remove_error}): {exc}"
                 )
 
             if not text:

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -6,6 +6,8 @@ import requests
 import time
 import random
 import tempfile
+from defusedxml import ElementTree as DefusedElementTree
+from defusedxml.common import DefusedXmlException
 from ..paper import Paper
 from ..utils import extract_doi
 from .base import PaperSource
@@ -737,10 +739,12 @@ class SemanticSearcher(PaperSource):
 
     @staticmethod
     def _parse_article_xml(xml_content: bytes) -> ET.Element:
-        if re.search(br"<!\s*(?:doctype|entity)\b", xml_content, flags=re.IGNORECASE):
-            raise ValueError("Unsafe XML declaration in Europe PMC full text")
-
-        return ET.fromstring(xml_content, parser=ET.XMLParser())
+        try:
+            return DefusedElementTree.fromstring(xml_content)
+        except DefusedXmlException as exc:
+            raise ValueError(
+                "Unsafe XML declaration in Europe PMC full text"
+            ) from exc
 
     def _extract_text_from_article_xml(self, xml_content: bytes) -> str:
         root = self._parse_article_xml(xml_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "beautifulsoup4>=4.12.0",
     "lxml>=4.9.0",
     "httpx[socks]>=0.28.1",
+    "defusedxml>=0.7.1",
 ]
 
 [project.urls]

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -40,18 +40,20 @@ class TestSemanticSearcher(unittest.TestCase):
         response.content = content
         response.headers = {"Content-Type": content_type}
         response.url = url
-        response.raise_for_status.side_effect = error
+        if error is not None:
+            response.raise_for_status.side_effect = error
+        else:
+            response.raise_for_status.side_effect = None
+            response.raise_for_status.return_value = None
         return response
 
     def test_download_pdf_saves_file_when_pdf_url_available(self):
         paper = SimpleNamespace(pdf_url="https://example.com/paper.pdf")
-        response = Mock()
-        response.content = b"%PDF-1.4 test content"
-        response.raise_for_status.return_value = None
+        response = self._mock_response(b"%PDF-1.4 test content")
 
         with tempfile.TemporaryDirectory(prefix="semantic_mock_download_") as test_dir:
             with patch.object(self.searcher, "get_paper_details", return_value=paper):
-                with patch("paper_search_mcp.academic_platforms.semantic.requests.get", return_value=response):
+                with patch.object(self.searcher.session, "get", return_value=response):
                     result = self.searcher.download_pdf("paper/123", test_dir)
 
             expected_path = Path(test_dir) / "semantic_paper_123.pdf"
@@ -81,8 +83,9 @@ class TestSemanticSearcher(unittest.TestCase):
 
         with tempfile.TemporaryDirectory(prefix="semantic_fallback_") as test_dir:
             with patch.object(self.searcher, "get_paper_details", return_value=paper):
-                with patch(
-                    "paper_search_mcp.academic_platforms.semantic.requests.get",
+                with patch.object(
+                    self.searcher.session,
+                    "get",
                     side_effect=[forbidden_response, pdf_response],
                 ) as mocked_get:
                     result = self.searcher.download_pdf("paper/123", test_dir)
@@ -109,8 +112,9 @@ class TestSemanticSearcher(unittest.TestCase):
 
         with tempfile.TemporaryDirectory(prefix="semantic_pmc_fallback_") as test_dir:
             with patch.object(self.searcher, "get_paper_details", return_value=paper):
-                with patch(
-                    "paper_search_mcp.academic_platforms.semantic.requests.get",
+                with patch.object(
+                    self.searcher.session,
+                    "get",
                     return_value=pdf_response,
                 ) as mocked_get:
                     result = self.searcher.download_pdf("paper/123", test_dir)
@@ -133,8 +137,9 @@ class TestSemanticSearcher(unittest.TestCase):
 
         with tempfile.TemporaryDirectory(prefix="semantic_html_download_") as test_dir:
             with patch.object(self.searcher, "get_paper_details", return_value=paper):
-                with patch(
-                    "paper_search_mcp.academic_platforms.semantic.requests.get",
+                with patch.object(
+                    self.searcher.session,
+                    "get",
                     return_value=html_response,
                 ):
                     result = self.searcher.download_pdf("paper/123", test_dir)
@@ -160,8 +165,9 @@ class TestSemanticSearcher(unittest.TestCase):
             cached_path.write_bytes(b"<!doctype html><html>cached challenge</html>")
 
             with patch.object(self.searcher, "get_paper_details", return_value=paper):
-                with patch(
-                    "paper_search_mcp.academic_platforms.semantic.requests.get",
+                with patch.object(
+                    self.searcher.session,
+                    "get",
                     return_value=pdf_response,
                 ):
                     result = self.searcher.download_pdf("paper/123", test_dir)

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -29,6 +29,20 @@ class TestSemanticSearcher(unittest.TestCase):
     def setUp(self):
         self.searcher = SemanticSearcher()
 
+    def _mock_response(
+        self,
+        content,
+        content_type="application/pdf",
+        url="https://example.com/paper.pdf",
+        error=None,
+    ):
+        response = Mock()
+        response.content = content
+        response.headers = {"Content-Type": content_type}
+        response.url = url
+        response.raise_for_status.side_effect = error
+        return response
+
     def test_download_pdf_saves_file_when_pdf_url_available(self):
         paper = SimpleNamespace(pdf_url="https://example.com/paper.pdf")
         response = Mock()
@@ -44,6 +58,116 @@ class TestSemanticSearcher(unittest.TestCase):
             self.assertEqual(result, str(expected_path))
             self.assertTrue(expected_path.exists())
             self.assertEqual(expected_path.read_bytes(), b"%PDF-1.4 test content")
+
+    def test_download_pdf_uses_pmcid_fallback_when_direct_url_is_forbidden(self):
+        direct_url = "https://academic.oup.com/article.pdf"
+        fallback_url = "https://europepmc.org/articles/PMC10516373?pdf=render"
+        paper = SimpleNamespace(
+            pdf_url=direct_url,
+            url="https://www.semanticscholar.org/paper/test",
+            extra={"externalIds": {"PubMedCentral": "10516373"}},
+        )
+        forbidden_response = self._mock_response(
+            b"<!DOCTYPE html><title>Just a moment...</title>",
+            content_type="text/html; charset=UTF-8",
+            url=direct_url,
+            error=requests.HTTPError("403 Client Error: Forbidden"),
+        )
+        pdf_response = self._mock_response(
+            b"%PDF-1.7 fallback content",
+            content_type="application/pdf",
+            url=fallback_url,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_fallback_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch(
+                    "paper_search_mcp.academic_platforms.semantic.requests.get",
+                    side_effect=[forbidden_response, pdf_response],
+                ) as mocked_get:
+                    result = self.searcher.download_pdf("paper/123", test_dir)
+
+            expected_path = Path(test_dir) / "semantic_paper_123.pdf"
+            self.assertEqual(result, str(expected_path))
+            self.assertEqual(expected_path.read_bytes(), b"%PDF-1.7 fallback content")
+            self.assertEqual(mocked_get.call_args_list[0].args[0], direct_url)
+            self.assertEqual(mocked_get.call_args_list[1].args[0], fallback_url)
+
+    def test_download_pdf_prefers_europe_pmc_for_pmc_article_url(self):
+        article_url = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11326250"
+        fallback_url = "https://europepmc.org/articles/PMC11326250?pdf=render"
+        paper = SimpleNamespace(
+            pdf_url=article_url,
+            url="https://www.semanticscholar.org/paper/test",
+            extra={"externalIds": {"PubMedCentral": "11326250"}},
+        )
+        pdf_response = self._mock_response(
+            b"%PDF-1.7 fallback content",
+            content_type="application/pdf",
+            url=fallback_url,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_pmc_fallback_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch(
+                    "paper_search_mcp.academic_platforms.semantic.requests.get",
+                    return_value=pdf_response,
+                ) as mocked_get:
+                    result = self.searcher.download_pdf("paper/123", test_dir)
+
+            expected_path = Path(test_dir) / "semantic_paper_123.pdf"
+            self.assertEqual(result, str(expected_path))
+            self.assertEqual(mocked_get.call_args.args[0], fallback_url)
+
+    def test_download_pdf_does_not_save_html_as_pdf(self):
+        paper = SimpleNamespace(
+            pdf_url="https://example.com/article",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={},
+        )
+        html_response = self._mock_response(
+            b"<!doctype html><html><body>not a pdf</body></html>",
+            content_type="text/html; charset=utf-8",
+            url="https://example.com/article",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_html_download_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch(
+                    "paper_search_mcp.academic_platforms.semantic.requests.get",
+                    return_value=html_response,
+                ):
+                    result = self.searcher.download_pdf("paper/123", test_dir)
+
+            expected_path = Path(test_dir) / "semantic_paper_123.pdf"
+            self.assertTrue(result.startswith("Error downloading PDF for paper/123"))
+            self.assertFalse(expected_path.exists())
+
+    def test_download_pdf_replaces_invalid_cached_file(self):
+        paper = SimpleNamespace(
+            pdf_url="https://example.com/paper.pdf",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={},
+        )
+        pdf_response = self._mock_response(
+            b"%PDF-1.7 replacement content",
+            content_type="application/pdf",
+            url="https://example.com/paper.pdf",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_bad_cache_") as test_dir:
+            cached_path = Path(test_dir) / "semantic_paper_123.pdf"
+            cached_path.write_bytes(b"<!doctype html><html>cached challenge</html>")
+
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch(
+                    "paper_search_mcp.academic_platforms.semantic.requests.get",
+                    return_value=pdf_response,
+                ):
+                    result = self.searcher.download_pdf("paper/123", test_dir)
+
+            self.assertEqual(result, str(cached_path))
+            self.assertEqual(cached_path.read_bytes(), b"%PDF-1.7 replacement content")
 
     def test_parse_paper_handles_missing_publication_date(self):
         item = {

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -41,6 +41,7 @@ class TestSemanticSearcher(unittest.TestCase):
         response.headers = {"Content-Type": content_type}
         response.url = url
         response.iter_content.return_value = iter([content])
+        response.close.return_value = None
         if error is not None:
             response.raise_for_status.side_effect = error
         else:
@@ -163,6 +164,32 @@ class TestSemanticSearcher(unittest.TestCase):
             expected_path = Path(test_dir) / "semantic_paper_123.pdf"
             self.assertTrue(result.startswith("Error downloading PDF for paper/123"))
             self.assertFalse(expected_path.exists())
+            html_response.close.assert_called_once()
+
+    def test_download_pdf_closes_streamed_response_after_success(self):
+        paper = SimpleNamespace(
+            pdf_url="https://example.com/paper.pdf",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={},
+        )
+        pdf_response = self._mock_response(
+            b"%PDF-1.7 streamed content",
+            content_type="application/pdf",
+            url="https://example.com/paper.pdf",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_stream_close_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(
+                    self.searcher.session,
+                    "get",
+                    return_value=pdf_response,
+                ):
+                    result = self.searcher.download_pdf("paper/123", test_dir)
+
+            expected_path = Path(test_dir) / "semantic_paper_123.pdf"
+            self.assertEqual(result, str(expected_path))
+            pdf_response.close.assert_called_once()
 
     def test_download_pdf_replaces_invalid_cached_file(self):
         paper = SimpleNamespace(
@@ -190,6 +217,33 @@ class TestSemanticSearcher(unittest.TestCase):
 
             self.assertEqual(result, str(cached_path))
             self.assertEqual(cached_path.read_bytes(), b"%PDF-1.7 replacement content")
+
+    def test_read_paper_removes_cached_pdf_when_extraction_fails(self):
+        paper = SimpleNamespace(
+            pdf_url="https://example.com/paper.pdf",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={},
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_corrupt_cache_") as test_dir:
+            cached_path = Path(test_dir) / "semantic_paper_123.pdf"
+            cached_path.write_bytes(b"%PDF corrupt cached content")
+
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(
+                    self.searcher,
+                    "_extract_pdf_text",
+                    side_effect=ValueError("broken pdf"),
+                ):
+                    with patch.object(
+                        self.searcher,
+                        "_read_europe_pmc_full_text",
+                        return_value=("", ""),
+                    ):
+                        result = self.searcher.read_paper("paper/123", test_dir)
+
+            self.assertIn("text extraction failed", result)
+            self.assertFalse(cached_path.exists())
 
     def test_parse_paper_handles_missing_publication_date(self):
         item = {

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -11,9 +11,13 @@ from paper_search_mcp.academic_platforms.semantic import SemanticSearcher
 def check_semantic_accessible():
     """Check if Semantic Scholar is accessible"""
     try:
-        response = requests.get("https://api.semanticscholar.org/graph/v1/paper/5bbfdf2e62f0508c65ba6de9c72fe2066fd98138", timeout=5)
+        response = requests.get(
+            "https://api.semanticscholar.org/graph/v1/paper/"
+            "5bbfdf2e62f0508c65ba6de9c72fe2066fd98138",
+            timeout=5,
+        )
         return response.status_code == 200
-    except:
+    except requests.RequestException:
         return False
 
 
@@ -35,12 +39,16 @@ class TestSemanticSearcher(unittest.TestCase):
         content_type="application/pdf",
         url="https://example.com/paper.pdf",
         error=None,
+        headers=None,
     ):
+        chunks = list(content) if isinstance(content, (list, tuple)) else [content]
         response = Mock()
-        response.content = content
+        response.content = b"".join(chunks)
         response.headers = {"Content-Type": content_type}
+        if headers:
+            response.headers.update(headers)
         response.url = url
-        response.iter_content.return_value = iter([content])
+        response.iter_content.return_value = iter(chunks)
         response.close.return_value = None
         if error is not None:
             response.raise_for_status.side_effect = error
@@ -62,6 +70,19 @@ class TestSemanticSearcher(unittest.TestCase):
             self.assertEqual(result, str(expected_path))
             self.assertTrue(expected_path.exists())
             self.assertEqual(expected_path.read_bytes(), b"%PDF-1.4 test content")
+
+    def test_download_pdf_accepts_split_pdf_header(self):
+        paper = SimpleNamespace(pdf_url="https://example.com/paper.pdf")
+        response = self._mock_response([b"%P", b"DF-1.4 split header"])
+
+        with tempfile.TemporaryDirectory(prefix="semantic_split_header_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(self.searcher.session, "get", return_value=response):
+                    result = self.searcher.download_pdf("paper/123", test_dir)
+
+            expected_path = Path(test_dir) / "semantic_paper_123.pdf"
+            self.assertEqual(result, str(expected_path))
+            self.assertEqual(expected_path.read_bytes(), b"%PDF-1.4 split header")
 
     def test_download_pdf_sanitizes_prefixed_identifier_for_filename(self):
         paper = SimpleNamespace(pdf_url="https://example.com/paper.pdf")
@@ -166,6 +187,31 @@ class TestSemanticSearcher(unittest.TestCase):
             self.assertFalse(expected_path.exists())
             html_response.close.assert_called_once()
 
+    def test_download_pdf_rejects_non_pdf_body_with_pdf_content_type(self):
+        paper = SimpleNamespace(
+            pdf_url="https://example.com/article.pdf",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={},
+        )
+        bad_response = self._mock_response(
+            b"not actually a pdf",
+            content_type="application/pdf",
+            url="https://example.com/article.pdf",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_fake_pdf_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(
+                    self.searcher.session,
+                    "get",
+                    return_value=bad_response,
+                ):
+                    result = self.searcher.download_pdf("paper/123", test_dir)
+
+            expected_path = Path(test_dir) / "semantic_paper_123.pdf"
+            self.assertTrue(result.startswith("Error downloading PDF for paper/123"))
+            self.assertFalse(expected_path.exists())
+
     def test_download_pdf_closes_streamed_response_after_success(self):
         paper = SimpleNamespace(
             pdf_url="https://example.com/paper.pdf",
@@ -190,6 +236,32 @@ class TestSemanticSearcher(unittest.TestCase):
             expected_path = Path(test_dir) / "semantic_paper_123.pdf"
             self.assertEqual(result, str(expected_path))
             pdf_response.close.assert_called_once()
+
+    def test_download_pdf_removes_partial_temp_file_after_stream_failure(self):
+        paper = SimpleNamespace(
+            pdf_url="https://example.com/paper.pdf",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={},
+        )
+
+        def broken_stream():
+            yield b"%PDF-1.7 partial content"
+            raise requests.ConnectionError("connection lost")
+
+        response = self._mock_response(
+            b"%PDF-1.7 partial content",
+            url="https://example.com/paper.pdf",
+        )
+        response.iter_content.return_value = broken_stream()
+
+        with tempfile.TemporaryDirectory(prefix="semantic_partial_stream_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(self.searcher.session, "get", return_value=response):
+                    result = self.searcher.download_pdf("paper/123", test_dir)
+
+            self.assertTrue(result.startswith("Error downloading PDF for paper/123"))
+            self.assertEqual(list(Path(test_dir).iterdir()), [])
+            response.close.assert_called_once()
 
     def test_download_pdf_replaces_invalid_cached_file(self):
         paper = SimpleNamespace(
@@ -243,7 +315,81 @@ class TestSemanticSearcher(unittest.TestCase):
                         result = self.searcher.read_paper("paper/123", test_dir)
 
             self.assertIn("text extraction failed", result)
+            self.assertIn("cached PDF was removed", result)
+            self.assertNotIn("PDF downloaded to", result)
             self.assertFalse(cached_path.exists())
+
+    def test_read_paper_omits_removed_pdf_path_when_full_text_fallback_succeeds(self):
+        paper = SimpleNamespace(
+            title="Fallback article",
+            authors=["Ada Lovelace"],
+            published_date=None,
+            pdf_url="https://example.com/paper.pdf",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={"externalIds": {"PubMedCentral": "123456"}},
+        )
+
+        with tempfile.TemporaryDirectory(
+            prefix="semantic_full_text_after_corrupt_"
+        ) as test_dir:
+            cached_path = Path(test_dir) / "semantic_paper_123.pdf"
+            cached_path.write_bytes(b"%PDF corrupt cached content")
+
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(
+                    self.searcher,
+                    "_extract_pdf_text",
+                    side_effect=ValueError("broken pdf"),
+                ):
+                    with patch.object(
+                        self.searcher,
+                        "_read_europe_pmc_full_text",
+                        return_value=("Recovered full text", "https://example.com/xml"),
+                    ):
+                        result = self.searcher.read_paper("paper/123", test_dir)
+
+            self.assertIn("Full text source: https://example.com/xml", result)
+            self.assertIn("Recovered full text", result)
+            self.assertNotIn("PDF downloaded to:", result)
+            self.assertFalse(cached_path.exists())
+
+    def test_read_europe_pmc_full_text_closes_response(self):
+        paper = SimpleNamespace(
+            pdf_url="",
+            url="",
+            extra={"externalIds": {"PubMedCentral": "123456"}},
+        )
+        response = self._mock_response(
+            b"""
+            <article>
+              <front>
+                <article-meta>
+                  <title-group>
+                    <article-title>Article title</article-title>
+                  </title-group>
+                  <abstract><p>Abstract text</p></abstract>
+                </article-meta>
+              </front>
+              <body><sec><title>Results</title><p>Body text</p></sec></body>
+            </article>
+            """,
+            content_type="application/xml",
+            url=(
+                "https://www.ebi.ac.uk/europepmc/webservices/rest/"
+                "PMC123456/fullTextXML"
+            ),
+        )
+
+        with patch.object(self.searcher.session, "get", return_value=response):
+            text, source = self.searcher._read_europe_pmc_full_text(paper)
+
+        self.assertEqual(
+            source,
+            "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC123456/fullTextXML",
+        )
+        self.assertIn("Article title", text)
+        self.assertIn("Body text", text)
+        response.close.assert_called_once()
 
     def test_parse_paper_handles_missing_publication_date(self):
         item = {
@@ -373,19 +519,24 @@ class TestSemanticSearcher(unittest.TestCase):
                 self.assertIn("Title:", result)
                 self.assertIn("Authors:", result)
                 self.assertIn("Published Date:", result)
-                self.assertIn("PDF downloaded to:", result)
+                self.assertTrue(
+                    "PDF downloaded to:" in result or "Full text source:" in result
+                )
 
-                # Should contain page markers indicating text extraction
-                self.assertIn("--- Page", result)
+                if "PDF downloaded to:" in result:
+                    # Should contain page markers indicating PDF text extraction
+                    self.assertIn("--- Page", result)
 
-                # Check if PDF was actually downloaded
-                expected_filename = f"iacr_{paper_id.replace('/', '_')}.pdf"
-                expected_path = os.path.join(test_dir, expected_filename)
-                self.assertTrue(os.path.exists(expected_path))
+                    # Check if PDF was actually downloaded
+                    expected_filename = (
+                        f"semantic_{self.searcher._safe_paper_id(paper_id)}.pdf"
+                    )
+                    expected_path = os.path.join(test_dir, expected_filename)
+                    self.assertTrue(os.path.exists(expected_path))
 
-                file_size = os.path.getsize(expected_path)
-                print(f"PDF file found: {expected_path} (size: {file_size} bytes)")
-                self.assertGreater(file_size, 1000)  # Should be at least 1KB
+                    file_size = os.path.getsize(expected_path)
+                    print(f"PDF file found: {expected_path} (size: {file_size} bytes)")
+                    self.assertGreater(file_size, 1000)  # Should be at least 1KB
 
                 # Show a preview of extracted text
                 preview = result[:500] + "..." if len(result) > 500 else result

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -1,22 +1,26 @@
 import unittest
 import os
+import shutil
 import requests
 import tempfile
+import time
+from functools import lru_cache
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from paper_search_mcp.academic_platforms.semantic import SemanticSearcher
 
 
+@lru_cache(maxsize=1)
 def check_semantic_accessible():
     """Check if Semantic Scholar is accessible"""
     try:
-        response = requests.get(
+        with requests.get(
             "https://api.semanticscholar.org/graph/v1/paper/"
             "5bbfdf2e62f0508c65ba6de9c72fe2066fd98138",
             timeout=5,
-        )
-        return response.status_code == 200
+        ) as response:
+            return response.status_code == 200
     except requests.RequestException:
         return False
 
@@ -394,7 +398,9 @@ class TestSemanticSearcher(unittest.TestCase):
             extra={},
         )
 
-        with tempfile.TemporaryDirectory(prefix="semantic_cache_remove_error_") as test_dir:
+        with tempfile.TemporaryDirectory(
+            prefix="semantic_cache_remove_error_"
+        ) as test_dir:
             cached_path = Path(test_dir) / "semantic_paper_123.pdf"
             cached_path.write_bytes(b"%PDF corrupt cached content")
 
@@ -481,8 +487,7 @@ class TestSemanticSearcher(unittest.TestCase):
             """,
             content_type="application/xml",
             url=(
-                "https://www.ebi.ac.uk/europepmc/webservices/rest/"
-                "PMC123456/fullTextXML"
+                "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC123456/fullTextXML"
             ),
         )
 
@@ -527,6 +532,22 @@ class TestSemanticSearcher(unittest.TestCase):
         self.assertIsNotNone(paper)
         self.assertIsNone(paper.published_date)
 
+    def test_semantic_accessibility_probe_is_memoized(self):
+        check_semantic_accessible.cache_clear()
+        response = MagicMock()
+        response.status_code = 200
+        response.__enter__.return_value = response
+
+        try:
+            with patch.object(requests, "get", return_value=response) as mocked_get:
+                self.assertTrue(check_semantic_accessible())
+                self.assertTrue(check_semantic_accessible())
+
+            mocked_get.assert_called_once()
+            response.__exit__.assert_called_once()
+        finally:
+            check_semantic_accessible.cache_clear()
+
     @unittest.skipUnless(check_semantic_accessible(), "Semantic Scholar not accessible")
     def test_search_basic(self):
         """Test basic search functionality"""
@@ -559,9 +580,6 @@ class TestSemanticSearcher(unittest.TestCase):
     @unittest.skipUnless(check_semantic_accessible(), "Semantic Scholar not accessible")
     def test_download_pdf_functionality(self):
         """Test PDF download method with actual download"""
-        import tempfile
-        import shutil
-
         # Create a temporary directory for testing
         test_dir = tempfile.mkdtemp(prefix="semantic_test_")
 
@@ -612,9 +630,6 @@ class TestSemanticSearcher(unittest.TestCase):
     @unittest.skipUnless(check_semantic_accessible(), "Semantic Scholar not accessible")
     def test_read_paper_functionality(self):
         """Test read paper method with text extraction functionality"""
-        import tempfile
-        import shutil
-
         # Create a temporary directory for testing
         test_dir = tempfile.mkdtemp(prefix="semantic_read_test_")
 
@@ -682,7 +697,9 @@ class TestSemanticSearcher(unittest.TestCase):
         paper_details = self.searcher.get_paper_details(paper_id)
 
         if not paper_details:
-            self.skipTest("Semantic Scholar details endpoint is rate-limited or unavailable")
+            self.skipTest(
+                "Semantic Scholar details endpoint is rate-limited or unavailable"
+            )
 
         # Test basic attributes
         self.assertTrue(paper_details.title)
@@ -758,24 +775,18 @@ class TestSemanticSearcher(unittest.TestCase):
     @unittest.skipUnless(check_semantic_accessible(), "Semantic Scholar not accessible")
     def test_search_performance_comparison(self):
         """Test performance difference between detailed and compact search"""
-        import time
-
         query = "encryption"
         max_results = 3
 
         # Test detailed search time
         print("\nTesting detailed search performance...")
         start_time = time.time()
-        compact_papers = self.searcher.search(
-            query, max_results=max_results
-        )
+        compact_papers = self.searcher.search(query, max_results=max_results)
         compact_time = time.time() - start_time
 
         print(
             f"Compact search took {compact_time:.2f} seconds for {len(compact_papers)} papers"
         )
-
-
 
 
 if __name__ == "__main__":

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -387,6 +387,40 @@ class TestSemanticSearcher(unittest.TestCase):
             self.assertNotIn("PDF downloaded to", result)
             self.assertFalse(cached_path.exists())
 
+    def test_read_paper_reports_cache_removal_error_after_extraction_failure(self):
+        paper = SimpleNamespace(
+            pdf_url="https://example.com/paper.pdf",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={},
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_cache_remove_error_") as test_dir:
+            cached_path = Path(test_dir) / "semantic_paper_123.pdf"
+            cached_path.write_bytes(b"%PDF corrupt cached content")
+
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(
+                    self.searcher,
+                    "_extract_pdf_text",
+                    side_effect=ValueError("broken pdf"),
+                ):
+                    with patch.object(
+                        self.searcher,
+                        "_remove_pdf_file",
+                        return_value="permission denied",
+                    ):
+                        with patch.object(
+                            self.searcher,
+                            "_read_europe_pmc_full_text",
+                            return_value=("", ""),
+                        ):
+                            result = self.searcher.read_paper("paper/123", test_dir)
+
+            self.assertIn("text extraction failed", result)
+            self.assertIn("cached PDF could not be removed", result)
+            self.assertIn("permission denied", result)
+            self.assertIn("broken pdf", result)
+
     def test_read_paper_omits_removed_pdf_path_when_full_text_fallback_succeeds(self):
         paper = SimpleNamespace(
             title="Fallback article",

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -99,6 +99,34 @@ class TestSemanticSearcher(unittest.TestCase):
             self.assertEqual(result, str(expected_path))
             self.assertTrue(expected_path.exists())
 
+    def test_download_pdf_caps_long_identifier_for_filename(self):
+        paper = SimpleNamespace(pdf_url="https://example.com/paper.pdf")
+        response = self._mock_response(b"%PDF-1.4 test content")
+        paper_id = "URL:https://example.com/" + ("very-long-path/" * 30)
+
+        with tempfile.TemporaryDirectory(prefix="semantic_long_filename_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(self.searcher.session, "get", return_value=response):
+                    result = self.searcher.download_pdf(paper_id, test_dir)
+
+            filename = Path(result).name
+            safe_id = filename.removeprefix("semantic_").removesuffix(".pdf")
+            self.assertLessEqual(
+                len(safe_id),
+                self.searcher.SAFE_PAPER_ID_MAX_LENGTH,
+            )
+            self.assertTrue(Path(result).exists())
+
+    def test_safe_paper_id_adds_hash_for_distinct_long_identifiers(self):
+        base_id = "URL:https://example.com/" + ("segment/" * 40)
+
+        first = self.searcher._safe_paper_id(base_id + "a")
+        second = self.searcher._safe_paper_id(base_id + "b")
+
+        self.assertLessEqual(len(first), self.searcher.SAFE_PAPER_ID_MAX_LENGTH)
+        self.assertLessEqual(len(second), self.searcher.SAFE_PAPER_ID_MAX_LENGTH)
+        self.assertNotEqual(first, second)
+
     def test_download_pdf_uses_pmcid_fallback_when_direct_url_is_forbidden(self):
         direct_url = "https://academic.oup.com/article.pdf"
         fallback_url = "https://europepmc.org/articles/PMC10516373?pdf=render"
@@ -290,6 +318,20 @@ class TestSemanticSearcher(unittest.TestCase):
             self.assertEqual(result, str(cached_path))
             self.assertEqual(cached_path.read_bytes(), b"%PDF-1.7 replacement content")
 
+    def test_download_pdf_returns_valid_cached_file_without_api_lookup(self):
+        with tempfile.TemporaryDirectory(prefix="semantic_valid_cache_") as test_dir:
+            cached_path = Path(test_dir) / "semantic_paper_123.pdf"
+            cached_path.write_bytes(b"%PDF-1.7 cached content")
+
+            with patch.object(
+                self.searcher,
+                "get_paper_details",
+                side_effect=AssertionError("API lookup should not be called"),
+            ):
+                result = self.searcher.download_pdf("paper/123", test_dir)
+
+            self.assertEqual(result, str(cached_path))
+
     def test_read_paper_removes_cached_pdf_when_extraction_fails(self):
         paper = SimpleNamespace(
             pdf_url="https://example.com/paper.pdf",
@@ -390,6 +432,17 @@ class TestSemanticSearcher(unittest.TestCase):
         self.assertIn("Article title", text)
         self.assertIn("Body text", text)
         response.close.assert_called_once()
+
+    def test_extract_text_from_article_xml_rejects_dtd(self):
+        unsafe_xml = b"""
+        <!DOCTYPE article [
+          <!ENTITY repeated "unsafe">
+        ]>
+        <article><body><p>&repeated;</p></body></article>
+        """
+
+        with self.assertRaisesRegex(ValueError, "Unsafe XML declaration"):
+            self.searcher._extract_text_from_article_xml(unsafe_xml)
 
     def test_parse_paper_handles_missing_publication_date(self):
         item = {

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -40,6 +40,7 @@ class TestSemanticSearcher(unittest.TestCase):
         response.content = content
         response.headers = {"Content-Type": content_type}
         response.url = url
+        response.iter_content.return_value = iter([content])
         if error is not None:
             response.raise_for_status.side_effect = error
         else:
@@ -60,6 +61,21 @@ class TestSemanticSearcher(unittest.TestCase):
             self.assertEqual(result, str(expected_path))
             self.assertTrue(expected_path.exists())
             self.assertEqual(expected_path.read_bytes(), b"%PDF-1.4 test content")
+
+    def test_download_pdf_sanitizes_prefixed_identifier_for_filename(self):
+        paper = SimpleNamespace(pdf_url="https://example.com/paper.pdf")
+        response = self._mock_response(b"%PDF-1.4 test content")
+
+        with tempfile.TemporaryDirectory(prefix="semantic_safe_filename_") as test_dir:
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(self.searcher.session, "get", return_value=response):
+                    result = self.searcher.download_pdf(
+                        "DOI:10.18653/v1/N18-3011", test_dir
+                    )
+
+            expected_path = Path(test_dir) / "semantic_DOI_10.18653_v1_N18-3011.pdf"
+            self.assertEqual(result, str(expected_path))
+            self.assertTrue(expected_path.exists())
 
     def test_download_pdf_uses_pmcid_fallback_when_direct_url_is_forbidden(self):
         direct_url = "https://academic.oup.com/article.pdf"

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -332,6 +332,32 @@ class TestSemanticSearcher(unittest.TestCase):
 
             self.assertEqual(result, str(cached_path))
 
+    def test_read_paper_fetches_metadata_for_valid_cached_pdf(self):
+        paper = SimpleNamespace(
+            title="Cached article",
+            authors=["Ada Lovelace"],
+            published_date=None,
+            pdf_url="https://example.com/paper.pdf",
+            url="https://www.semanticscholar.org/paper/test",
+            extra={},
+        )
+
+        with tempfile.TemporaryDirectory(prefix="semantic_cached_read_") as test_dir:
+            cached_path = Path(test_dir) / "semantic_paper_123.pdf"
+            cached_path.write_bytes(b"%PDF-1.7 cached content")
+
+            with patch.object(self.searcher, "get_paper_details", return_value=paper):
+                with patch.object(
+                    self.searcher,
+                    "_extract_pdf_text",
+                    return_value="Cached PDF text",
+                ):
+                    result = self.searcher.read_paper("paper/123", test_dir)
+
+            self.assertIn("Title: Cached article", result)
+            self.assertIn("Authors: Ada Lovelace", result)
+            self.assertIn("Cached PDF text", result)
+
     def test_read_paper_removes_cached_pdf_when_extraction_fails(self):
         paper = SimpleNamespace(
             pdf_url="https://example.com/paper.pdf",
@@ -377,6 +403,10 @@ class TestSemanticSearcher(unittest.TestCase):
             cached_path = Path(test_dir) / "semantic_paper_123.pdf"
             cached_path.write_bytes(b"%PDF corrupt cached content")
 
+            def full_text_fallback(fallback_paper):
+                self.assertIs(fallback_paper, paper)
+                return "Recovered full text", "https://example.com/xml"
+
             with patch.object(self.searcher, "get_paper_details", return_value=paper):
                 with patch.object(
                     self.searcher,
@@ -386,7 +416,7 @@ class TestSemanticSearcher(unittest.TestCase):
                     with patch.object(
                         self.searcher,
                         "_read_europe_pmc_full_text",
-                        return_value=("Recovered full text", "https://example.com/xml"),
+                        side_effect=full_text_fallback,
                     ):
                         result = self.searcher.read_paper("paper/123", test_dir)
 

--- a/uv.lock
+++ b/uv.lock
@@ -431,6 +431,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -936,6 +945,7 @@ version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "defusedxml" },
     { name = "fastmcp" },
     { name = "feedparser" },
     { name = "httpx", extra = ["socks"] },
@@ -948,6 +958,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastmcp" },
     { name = "feedparser" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary

- Treat Semantic Scholar `openAccessPdf.url` as a candidate URL instead of assuming it is always a direct PDF.
- Validate downloaded bytes/content type before saving or parsing as PDF.
- Add PMCID-based Europe PMC/PMC PDF fallbacks and Europe PMC full-text XML fallback for reads.
- Remove invalid cached PDF files before retrying downloads.
- Add regression tests for publisher 403s, HTML responses saved as PDFs, PMC article URL fallback, and invalid cache replacement.

## Root Cause

Semantic Scholar can return publisher, DOI, or PMC article URLs in `openAccessPdf.url`. Some of those URLs return HTML challenge/landing pages or HTTP 403 responses rather than PDF bytes. The previous Semantic connector wrote successful HTTP 200 responses directly to `.pdf` files and then handed them to PyPDF, which produced errors such as `invalid pdf header: b"<!doc"` and `Stream has ended unexpectedly`.

## Impact

The Semantic connector now fails cleanly when a URL is not a PDF, avoids leaving bogus cached PDFs behind, and recovers common open-access cases by using PMCID metadata to fetch PDFs from Europe PMC.

## Validation

- Semantic connector tests pass.
- The originally failing Semantic Scholar IDs now download real PDF files and `read` extracts text successfully.
- Additional live checks covered direct PDF URLs, PMC article URL fallback, DOI landing URL with PMCID fallback, and DOI landing URL without PMCID.
