### PR TITLE
Improve DOI fallback downloads and Sci-Hub mirror handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,13 +252,13 @@ paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads --no-scihub
 paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads
 ```
 
-For broad topic search, the CLI defaults to `-s fast`, which keeps arXiv in
-the search set but avoids known slow/noisy topic-search paths such as
-anonymous Semantic Scholar retries, CORE, PMC, Google Scholar, and Unpaywall.
+For broad topic search, the CLI defaults to `-s fast`, which avoids known
+slow/noisy topic-search paths such as arXiv network timeouts, anonymous
+Semantic Scholar retries, CORE, PMC, Google Scholar, and Unpaywall.
 If `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured, Semantic Scholar
 is added back to the fast set because authenticated access avoids the anonymous
 rate-limit delay. Use `-s fastest` for only OpenAlex and Crossref, or
-`--exhaustive -s all` when coverage matters more than latency.
+`-s arxiv` / `--exhaustive -s all` when coverage matters more than latency.
 
 Use `download-doi` for DOI retrieval. `unpaywall` is automatically added to
 generic `search` only when the query contains a DOI, because Unpaywall is a DOI

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Sci-Hub support can remain available as an optional connector for users who expl
 - Legal and policy risks vary by jurisdiction.
 - README and tool descriptions should clearly state that users are responsible for enabling and using it.
 - Open-access and publisher-permitted sources should be tried first whenever possible.
+- Mirror discovery from `sci-hub.now.sh` is inspired by the MIT-licensed
+  [`OpenByteDev/scihub-scraper-cli`](https://github.com/OpenByteDev/scihub-scraper-cli)
+  project.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,10 @@ The skill uses a CLI (`paper-search`) that wraps the same library as the MCP ser
 Useful CLI examples:
 
 ```bash
-paper-search search "gender imbalance neuroscience references" -n 3
-paper-search search "gender imbalance neuroscience references" -s fastest -n 3
-paper-search search "gender imbalance neuroscience references" --exhaustive -s all -n 3
+paper-search search "gender imbalance neuroscience references"
+paper-search search "gender imbalance neuroscience references" -s fastest
+paper-search search "gender imbalance neuroscience references" --include-abstracts
+paper-search search "gender imbalance neuroscience references" --exhaustive -s all
 paper-search metadata-dois 10.1038/s41593-020-0658-y 10.1111/ecog.03049 -o metadata.json
 paper-search metadata-dois --input dois.txt --output metadata.json
 paper-search download semantic DOI:10.1038/s41593-020-0658-y -o ./downloads
@@ -260,6 +261,9 @@ and Unpaywall.
 The default per-source search timeout is 5 seconds; arXiv normally responds far
 faster than that, and late network hangs are cut off without dropping arXiv from
 the default search set.
+Search returns up to 10 results per source by default and omits abstracts to
+keep agent context compact. Add `--include-abstracts` when you want to inspect
+abstracts directly, or use `metadata-dois` after deduplicating candidate DOIs.
 If `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured, Semantic Scholar
 is added back to the fast set because authenticated access avoids the anonymous
 rate-limit delay. Use `-s fastest` for only OpenAlex and Crossref, or

--- a/README.md
+++ b/README.md
@@ -267,7 +267,10 @@ lookup service rather than a broad topic search engine.
 Use `metadata-dois` after external/native discovery to enrich candidate papers
 in parallel. It accepts DOI arguments or a text file, queries Crossref,
 OpenAlex, and Unpaywall by default, and includes Semantic Scholar automatically
-when `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured.
+when `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured. Each merged
+metadata record includes deterministic prioritization fields such as
+`rank_score`, `rank_components`, `rank_reasons`, and `source_coverage` so
+agents can triage which papers to inspect first without calling an LLM.
 
 Use `download-doi` when you already have a DOI and want the tool to try the
 source-native path, Unpaywall, repository fallbacks, and optional Sci-Hub

--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ when `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured. Each merged
 metadata record includes deterministic prioritization fields such as
 `rank_score`, `rank_components`, `rank_reasons`, and `source_coverage` so
 agents can triage which papers to inspect first without calling an LLM.
+PDF availability in the ranking is based on all fast metadata sources checked
+for that DOI, exposed as `oa_pdf_sources`; mirror probing is reserved for
+`download-doi` so ranking stays fast and parallelizable.
 
 Use `download-doi` when you already have a DOI and want the tool to try the
 source-native path, Unpaywall, repository fallbacks, and optional Sci-Hub

--- a/README.md
+++ b/README.md
@@ -252,13 +252,15 @@ paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads --no-scihub
 paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads
 ```
 
-For broad topic search, the CLI defaults to `-s fast`, which avoids known
-slow/noisy topic-search paths such as arXiv network timeouts, anonymous
-Semantic Scholar retries, CORE, PMC, Google Scholar, and Unpaywall.
+For broad topic search, the CLI defaults to `-s fast`, which keeps arXiv in
+the search set but isolates each source in a child process so slow network
+timeouts cannot stall the whole command. It avoids known slow/noisy topic-search
+paths such as anonymous Semantic Scholar retries, CORE, PMC, Google Scholar,
+and Unpaywall.
 If `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured, Semantic Scholar
 is added back to the fast set because authenticated access avoids the anonymous
 rate-limit delay. Use `-s fastest` for only OpenAlex and Crossref, or
-`-s arxiv` / `--exhaustive -s all` when coverage matters more than latency.
+`--exhaustive -s all` when coverage matters more than latency.
 
 Use `download-doi` for DOI retrieval. `unpaywall` is automatically added to
 generic `search` only when the query contains a DOI, because Unpaywall is a DOI

--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ the search set but isolates each source in a child process so slow network
 timeouts cannot stall the whole command. It avoids known slow/noisy topic-search
 paths such as anonymous Semantic Scholar retries, CORE, PMC, Google Scholar,
 and Unpaywall.
+The default per-source search timeout is 5 seconds; arXiv normally responds far
+faster than that, and late network hangs are cut off without dropping arXiv from
+the default search set.
 If `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured, Semantic Scholar
 is added back to the fast set because authenticated access avoids the anonymous
 rate-limit delay. Use `-s fastest` for only OpenAlex and Crossref, or

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 - **Free-First Design**: Open and public sources are prioritized before any optional commercial or restricted integrations.
 - **Optional API-Key Enhancement**: Sources like Semantic Scholar can work better with a user-provided API key, but are not intended to force paid usage.
 - **Discovery + Retrieval Workflow**: Google Scholar and Crossref can be used for discovery and DOI backfilling, while open repositories and publisher links are used for lawful full-text resolution where available.
-- **OA-First Fallback Chain**: `download_with_fallback` now follows source-native download → OpenAIRE/CORE/Europe PMC/PMC discovery → Unpaywall DOI resolution → optional Sci-Hub.
+- **OA-First Fallback Chain**: `download_with_fallback` now follows source-native download → Unpaywall DOI resolution → OpenAIRE/CORE/Europe PMC/PMC discovery → optional Sci-Hub.
 - **MCP Integration**: Compatible with MCP clients for LLM context enhancement.
 - **Extensible Design**: Easily add new academic platforms by extending the `academic_platforms` module.
 
@@ -125,6 +125,11 @@ All keys are **optional** unless noted. Configure them in `.env` (preferred) or 
 | `PAPER_SEARCH_MCP_ZENODO_ACCESS_TOKEN` | Zenodo | Optional | Free at [zenodo.org](https://zenodo.org/account/settings/applications/) — required for private records |
 | `PAPER_SEARCH_MCP_IEEE_API_KEY` | IEEE Xplore | **Required to activate** | Free at [developer.ieee.org](https://developer.ieee.org/) |
 | `PAPER_SEARCH_MCP_ACM_API_KEY` | ACM DL | **Required to activate** | See [libraries.acm.org/digital-library/acm-open](https://libraries.acm.org/digital-library/acm-open) |
+| `PAPER_SEARCH_MCP_SCIHUB_MIRRORS` | Sci-Hub | Optional | Comma-separated preferred mirrors for optional Sci-Hub fallback |
+| `PAPER_SEARCH_MCP_SCIHUB_MIRROR_CACHE_TTL` | Sci-Hub | Optional | Mirror cache TTL in seconds (default: 21600) |
+| `PAPER_SEARCH_MCP_SCIHUB_MIRROR_PROBE_TIMEOUT` | Sci-Hub | Optional | Seconds per mirror health probe (default: 4) |
+| `PAPER_SEARCH_MCP_SCIHUB_MIRROR_DISCOVERY_TIMEOUT` | Sci-Hub | Optional | Seconds for mirror-list discovery (default: 5) |
+| `PAPER_SEARCH_MCP_SCIHUB_MIRROR_PROBE_WORKERS` | Sci-Hub | Optional | Parallel mirror health probes (default: 8) |
 
 All variables follow the `PAPER_SEARCH_MCP_<NAME>` prefix scheme. Legacy names without the prefix (e.g. `CORE_API_KEY`, `UNPAYWALL_EMAIL`) are still supported for backward compatibility.
 
@@ -232,6 +237,19 @@ Create a `.env` file in the repo root for optional API keys (see [Environment Va
 - "Download the PDF for arxiv paper 2106.12345"
 
 The skill uses a CLI (`paper-search`) that wraps the same library as the MCP server, outputting JSON for search/download and plain text for read.
+
+Useful CLI examples:
+
+```bash
+paper-search search "gender imbalance neuroscience references" -s openalex,crossref,unpaywall -n 3 --source-timeout 15
+paper-search download semantic DOI:10.1038/s41593-020-0658-y -o ./downloads
+paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads --no-scihub
+paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads
+```
+
+Use `download-doi` when you already have a DOI and want the tool to try the
+source-native path, Unpaywall, repository fallbacks, and optional Sci-Hub
+fallback without manually choosing a source-specific downloader.
 
 ---
 
@@ -485,6 +503,11 @@ PAPER_SEARCH_MCP_ZENODO_ACCESS_TOKEN=
 PAPER_SEARCH_MCP_GOOGLE_SCHOLAR_PROXY_URL=
 PAPER_SEARCH_MCP_IEEE_API_KEY=
 PAPER_SEARCH_MCP_ACM_API_KEY=
+PAPER_SEARCH_MCP_SCIHUB_MIRRORS=
+PAPER_SEARCH_MCP_SCIHUB_MIRROR_CACHE_TTL=21600
+PAPER_SEARCH_MCP_SCIHUB_MIRROR_PROBE_TIMEOUT=4
+PAPER_SEARCH_MCP_SCIHUB_MIRROR_DISCOVERY_TIMEOUT=5
+PAPER_SEARCH_MCP_SCIHUB_MIRROR_PROBE_WORKERS=8
 ```
 
 To use a custom path: `export PAPER_SEARCH_MCP_ENV_FILE=/absolute/path/to/.env`

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Useful CLI examples:
 paper-search search "gender imbalance neuroscience references" -n 3
 paper-search search "gender imbalance neuroscience references" -s fastest -n 3
 paper-search search "gender imbalance neuroscience references" --exhaustive -s all -n 3
+paper-search metadata-dois 10.1038/s41593-020-0658-y 10.1111/ecog.03049 -o metadata.json
+paper-search metadata-dois --input dois.txt --output metadata.json
 paper-search download semantic DOI:10.1038/s41593-020-0658-y -o ./downloads
 paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads --no-scihub
 paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads
@@ -261,6 +263,11 @@ rate-limit delay. Use `-s fastest` for only OpenAlex and Crossref, or
 Use `download-doi` for DOI retrieval. `unpaywall` is automatically added to
 generic `search` only when the query contains a DOI, because Unpaywall is a DOI
 lookup service rather than a broad topic search engine.
+
+Use `metadata-dois` after external/native discovery to enrich candidate papers
+in parallel. It accepts DOI arguments or a text file, queries Crossref,
+OpenAlex, and Unpaywall by default, and includes Semantic Scholar automatically
+when `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured.
 
 Use `download-doi` when you already have a DOI and want the tool to try the
 source-native path, Unpaywall, repository fallbacks, and optional Sci-Hub

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
   - **Layer 1 (Unified Tooling)**: High-level `search_papers` for multi-source concurrent search & deduplication, and `download_with_fallback` relying on publisher open access links with sequential fallbacks.
   - **Layer 2 (Platform Connectors)**: Modular connectors for specific academic platforms (arXiv, PubMed, bioRxiv, Semantic Scholar, etc.) equipped with intelligent DOI extraction via regex text analysis or API fields.
 - **Multi-Source Support**: Search and download papers from arXiv, PubMed, bioRxiv, medRxiv, Google Scholar, IACR ePrint Archive, Semantic Scholar, Crossref, OpenAlex, PubMed Central (PMC), CORE, Europe PMC, dblp, OpenAIRE, CiteSeerX, DOAJ, BASE, Zenodo, HAL, SSRN, Unpaywall (DOI lookup), and optional Sci-Hub workflows.
+- **Fast Search Defaults**: CLI search defaults to a curated fast set (OpenAlex, Crossref, arXiv, PubMed, Europe PMC). Slow or rate-limited broad sources remain available via explicit source selection or `--exhaustive`.
 - **Standardized Output**: Papers are returned in a consistent dictionary format via the `Paper` class.
 - **Free-First Design**: Open and public sources are prioritized before any optional commercial or restricted integrations.
 - **Optional API-Key Enhancement**: Sources like Semantic Scholar can work better with a user-provided API key, but are not intended to force paid usage.
@@ -241,11 +242,25 @@ The skill uses a CLI (`paper-search`) that wraps the same library as the MCP ser
 Useful CLI examples:
 
 ```bash
-paper-search search "gender imbalance neuroscience references" -s openalex,crossref,unpaywall -n 3 --source-timeout 15
+paper-search search "gender imbalance neuroscience references" -n 3
+paper-search search "gender imbalance neuroscience references" -s fastest -n 3
+paper-search search "gender imbalance neuroscience references" --exhaustive -s all -n 3
 paper-search download semantic DOI:10.1038/s41593-020-0658-y -o ./downloads
 paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads --no-scihub
 paper-search download-doi 10.1038/s41593-020-0658-y -o ./downloads
 ```
+
+For broad topic search, the CLI defaults to `-s fast`, which keeps arXiv in
+the search set but avoids known slow/noisy topic-search paths such as
+anonymous Semantic Scholar retries, CORE, PMC, Google Scholar, and Unpaywall.
+If `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured, Semantic Scholar
+is added back to the fast set because authenticated access avoids the anonymous
+rate-limit delay. Use `-s fastest` for only OpenAlex and Crossref, or
+`--exhaustive -s all` when coverage matters more than latency.
+
+Use `download-doi` for DOI retrieval. `unpaywall` is automatically added to
+generic `search` only when the query contains a DOI, because Unpaywall is a DOI
+lookup service rather than a broad topic search engine.
 
 Use `download-doi` when you already have a DOI and want the tool to try the
 source-native path, Unpaywall, repository fallbacks, and optional Sci-Hub

--- a/claude-code/SKILL.md
+++ b/claude-code/SKILL.md
@@ -18,7 +18,7 @@ Replace `<REPO_PATH>` with the absolute path to your clone of this repository.
 
 ### Search
 ```bash
-uv run --directory <REPO_PATH> paper-search search "<query>" -n <max_per_source> -s <sources> -y <year>
+uv run --directory <REPO_PATH> paper-search search "<query>" -n <max_per_source> -s <sources> -y <year> --source-timeout 30
 ```
 - `-n`: results per source (default: 5)
 - `-s`: comma-separated sources or "all" (default: all)
@@ -30,6 +30,16 @@ For speed, prefer targeted sources (`-s arxiv,semantic,crossref`) over "all" unl
 ```bash
 uv run --directory <REPO_PATH> paper-search download <source> <paper_id> [-o ./downloads]
 ```
+
+If the user provides a DOI and wants the PDF, prefer the DOI fallback command:
+
+```bash
+uv run --directory <REPO_PATH> paper-search download-doi <doi> [-o ./downloads] [--no-scihub]
+```
+
+This tries source-native download, Unpaywall, repository fallbacks, and optional
+Sci-Hub fallback without requiring the agent to choose a source-specific
+downloader.
 
 ### Read (extract text)
 ```bash
@@ -56,4 +66,5 @@ Optional (env vars): ieee (`IEEE_API_KEY`), acm (`ACM_API_KEY`)
 1. Search with targeted sources to find papers
 2. Present results as a table: title, authors, year, source, DOI/URL
 3. If the user wants full text, use `read <source> <paper_id>`
-4. If the user wants the PDF, use `download <source> <paper_id>` and report the saved path
+4. If the user gives a DOI and wants the PDF, use `download-doi <doi>` and report the saved path
+5. If a source-specific identifier is better, use `download <source> <paper_id>` and report the saved path

--- a/paper_search_mcp/academic_platforms/openalex.py
+++ b/paper_search_mcp/academic_platforms/openalex.py
@@ -153,6 +153,81 @@ class OpenAlexSearcher(PaperSource):
 
         return papers
 
+    def get_paper_by_doi(self, doi: str) -> Optional[Paper]:
+        """Fetch one OpenAlex work by DOI."""
+        normalized_doi = (doi or "").strip().replace("https://doi.org/", "")
+        if not normalized_doi:
+            return None
+
+        try:
+            params = {
+                "filter": f"doi:{normalized_doi}",
+                "per_page": 1,
+            }
+            response = self.session.get(self.BASE_URL, params=params, timeout=30)
+            if response.status_code != 200:
+                logger.error(
+                    "OpenAlex DOI lookup failed with status %s for DOI %s",
+                    response.status_code,
+                    normalized_doi,
+                )
+                return None
+
+            results = response.json().get("results", [])
+            if not results:
+                return None
+
+            paper_id = results[0].get("id", "").replace("https://openalex.org/", "")
+            title = results[0].get("title")
+            if not title:
+                return None
+
+            item = results[0]
+            authors = [
+                author.get("author", {}).get("display_name", "")
+                for author in item.get("authorships", [])
+                if author.get("author", {}).get("display_name")
+            ]
+            abstract = self._reconstruct_abstract(item.get("abstract_inverted_index"))
+            doi_value = (item.get("doi") or "").replace("https://doi.org/", "")
+            primary_location = item.get("primary_location") or {}
+            url = primary_location.get("landing_page_url") or item.get("id", "")
+            pdf_url = primary_location.get("pdf_url") or ""
+            open_access = item.get("open_access", {})
+            if not pdf_url and open_access.get("is_oa"):
+                pdf_url = open_access.get("oa_url", "")
+
+            published_date = None
+            pub_date_str = item.get("publication_date")
+            if pub_date_str:
+                try:
+                    published_date = datetime.strptime(pub_date_str, "%Y-%m-%d")
+                except ValueError:
+                    pass
+
+            concepts = [
+                concept.get("display_name")
+                for concept in item.get("concepts", [])
+                if concept.get("display_name")
+            ]
+
+            return Paper(
+                paper_id=paper_id,
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                url=url,
+                pdf_url=pdf_url or "",
+                published_date=published_date,
+                source="openalex",
+                categories=concepts[:5],
+                doi=doi_value or normalized_doi,
+                citations=item.get("cited_by_count", 0),
+            )
+        except Exception as e:
+            logger.error("OpenAlex DOI lookup error for %s: %s", normalized_doi, e)
+            return None
+
     def download_pdf(self, paper_id: str, save_path: str) -> str:
         """
         OpenAlex does not host PDFs natively, it only links to open access versions.

--- a/paper_search_mcp/academic_platforms/sci_hub.py
+++ b/paper_search_mcp/academic_platforms/sci_hub.py
@@ -192,7 +192,7 @@ class SciHubFetcher:
             return None
 
         except Exception as e:
-            logging.error(f"Error getting direct URL for {identifier}: {e}")
+            logging.debug("Error getting direct URL for %s via %s: %s", identifier, base_url or self.base_url, e)
             return None
 
     def get_candidate_mirrors(self, force_refresh: bool = False) -> list[str]:

--- a/paper_search_mcp/academic_platforms/sci_hub.py
+++ b/paper_search_mcp/academic_platforms/sci_hub.py
@@ -6,10 +6,28 @@ from pathlib import Path
 import re
 import hashlib
 import logging
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
 
 import requests
 from bs4 import BeautifulSoup
+
+from ..config import get_env
+from ..utils import is_pdf_content
+
+
+HARDCODED_MIRRORS = [
+    "https://sci-hub.se",
+    "https://sci-hub.st",
+    "https://sci-hub.ru",
+    "https://sci-hub.wf",
+    "https://sci-hub.al",
+    "https://sci-hub.mk",
+    "https://sci-hub.ee",
+    "https://sci-hub.shop",
+]
 
 
 class SciHubFetcher:
@@ -30,6 +48,13 @@ class SciHubFetcher:
             'Connection': 'keep-alive',
             'Upgrade-Insecure-Requests': '1',
         }
+        self.cache_file = Path(
+            get_env("SCIHUB_MIRROR_CACHE_FILE", "/tmp/paper-search-mcp-scihub-mirrors.json")
+        )
+        self.cache_ttl = int(get_env("SCIHUB_MIRROR_CACHE_TTL", "21600"))
+        self.probe_timeout = float(get_env("SCIHUB_MIRROR_PROBE_TIMEOUT", "4"))
+        self.discovery_timeout = float(get_env("SCIHUB_MIRROR_DISCOVERY_TIMEOUT", "5"))
+        self.probe_workers = int(get_env("SCIHUB_MIRROR_PROBE_WORKERS", "8"))
 
     def download_pdf(self, identifier: str) -> Optional[str]:
         """Download a PDF from Sci-Hub using a DOI, PMID, or URL.
@@ -44,10 +69,16 @@ class SciHubFetcher:
             return None
 
         try:
-            # Get direct URL to PDF
-            pdf_url = self._get_direct_url(identifier)
+            pdf_url = ""
+            mirror_used = self.base_url
+            for mirror in self.get_candidate_mirrors():
+                pdf_url = self._get_direct_url(identifier, base_url=mirror)
+                if pdf_url:
+                    mirror_used = mirror
+                    break
+
             if not pdf_url:
-                logging.error(f"Could not find PDF URL for identifier: {identifier}")
+                logging.error("Could not find PDF URL for identifier: %s", identifier)
                 return None
 
             # Download the PDF
@@ -57,7 +88,11 @@ class SciHubFetcher:
                 logging.error(f"Failed to download PDF, status {response.status_code}")
                 return None
 
-            if response.headers.get('Content-Type') != 'application/pdf':
+            if not is_pdf_content(
+                response.content,
+                content_type=response.headers.get("Content-Type", ""),
+                url=pdf_url,
+            ):
                 logging.error("Response is not a PDF")
                 return None
 
@@ -68,13 +103,14 @@ class SciHubFetcher:
             with open(file_path, 'wb') as f:
                 f.write(response.content)
                 
+            logging.info("Downloaded %s via Sci-Hub mirror %s", identifier, mirror_used)
             return str(file_path)
 
         except Exception as e:
             logging.error(f"Error downloading PDF for {identifier}: {e}")
             return None
 
-    def _get_direct_url(self, identifier: str) -> Optional[str]:
+    def _get_direct_url(self, identifier: str, base_url: Optional[str] = None) -> Optional[str]:
         """Get the direct PDF URL from Sci-Hub."""
         try:
             # If it's already a direct PDF URL, return it
@@ -82,7 +118,8 @@ class SciHubFetcher:
                 return identifier
 
             # Search on Sci-Hub
-            search_url = f"{self.base_url}/{identifier}"
+            active_base_url = (base_url or self.base_url).rstrip("/")
+            search_url = f"{active_base_url}/{identifier}"
             response = self.session.get(search_url, verify=False, timeout=20)
             
             if response.status_code != 200:
@@ -107,7 +144,7 @@ class SciHubFetcher:
                         logging.debug(f"Returning PDF URL: {pdf_url}")
                         return pdf_url
                     elif src.startswith('/'):
-                        pdf_url = self.base_url + src
+                        pdf_url = active_base_url + src
                         logging.debug(f"Returning PDF URL: {pdf_url}")
                         return pdf_url
                     else:
@@ -122,7 +159,7 @@ class SciHubFetcher:
                     if src.startswith('//'):
                         return 'https:' + src
                     elif src.startswith('/'):
-                        return self.base_url + src
+                        return active_base_url + src
                     else:
                         return src
 
@@ -137,7 +174,7 @@ class SciHubFetcher:
                         if url.startswith('//'):
                             return 'https:' + url
                         elif url.startswith('/'):
-                            return self.base_url + url
+                            return active_base_url + url
                         else:
                             return url
 
@@ -148,7 +185,7 @@ class SciHubFetcher:
                     if href.startswith('//'):
                         return 'https:' + href
                     elif href.startswith('/'):
-                        return self.base_url + href
+                        return active_base_url + href
                     elif href.startswith('http'):
                         return href
 
@@ -157,6 +194,150 @@ class SciHubFetcher:
         except Exception as e:
             logging.error(f"Error getting direct URL for {identifier}: {e}")
             return None
+
+    def get_candidate_mirrors(self, force_refresh: bool = False) -> list[str]:
+        """Return responsive mirrors, prioritizing configured and cached mirrors.
+
+        Mirror discovery from sci-hub.now.sh is inspired by the MIT-licensed
+        OpenByteDev/scihub-scraper-cli project.
+        """
+        configured = [
+            mirror.strip().rstrip("/")
+            for mirror in get_env("SCIHUB_MIRRORS", "").split(",")
+            if mirror.strip()
+        ]
+        candidates = configured or [self.base_url]
+
+        if not force_refresh:
+            cached = self._load_cached_mirrors()
+            if cached:
+                return self._dedupe(candidates + cached + HARDCODED_MIRRORS)
+
+        discovered = self._discover_mirrors()
+        healthy = self._health_check(self._dedupe(candidates + discovered + HARDCODED_MIRRORS))
+        if healthy:
+            self._save_cached_mirrors(healthy)
+            return healthy
+        return self._dedupe(candidates + HARDCODED_MIRRORS)
+
+    def _discover_mirrors(self) -> list[str]:
+        """Fetch current Sci-Hub mirror candidates from public mirror lists."""
+        mirrors: set[str] = set()
+        try:
+            response = self.session.get(
+                "https://sci-hub.now.sh",
+                timeout=self.discovery_timeout,
+            )
+            response.raise_for_status()
+        except Exception:
+            return []
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        for link in soup.find_all("a", href=True):
+            href = str(link.get("href", "")).strip()
+            if "sci-hub" in href or "scihub" in href:
+                mirrors.add(self._normalize_mirror(href))
+
+        for text_node in soup.find_all(string=True):
+            for word in str(text_node).split():
+                cleaned = word.strip(".,;()[]{}<>\"'")
+                if cleaned.startswith(("sci-hub.", "scihub.")):
+                    mirrors.add(self._normalize_mirror(cleaned))
+
+        return sorted(mirrors)
+
+    def _health_check(self, mirrors: list[str]) -> list[str]:
+        """Return mirrors that respond, sorted by observed latency."""
+        if not mirrors:
+            return []
+
+        results: list[tuple[float, str]] = []
+        workers = max(1, min(self.probe_workers, len(mirrors)))
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            future_to_mirror = {executor.submit(self._probe_mirror, mirror): mirror for mirror in mirrors}
+            for future in as_completed(future_to_mirror):
+                mirror = future_to_mirror[future]
+                try:
+                    latency = future.result()
+                except Exception:
+                    latency = None
+                if latency is not None:
+                    results.append((latency, mirror))
+
+        results.sort(key=lambda item: item[0])
+        return [mirror for _, mirror in results]
+
+    def _probe_mirror(self, mirror: str) -> Optional[float]:
+        start = time.time()
+        try:
+            response = self.session.head(
+                mirror,
+                timeout=self.probe_timeout,
+                allow_redirects=True,
+                verify=False,
+            )
+            if response.status_code < 500:
+                return time.time() - start
+        except Exception:
+            return None
+
+        if response.status_code not in (403, 405):
+            return None
+
+        try:
+            start = time.time()
+            response = self.session.get(
+                mirror,
+                timeout=self.probe_timeout,
+                allow_redirects=True,
+                stream=True,
+                verify=False,
+            )
+            if response.status_code < 500:
+                return time.time() - start
+        except Exception:
+            return None
+
+        return None
+
+    def _load_cached_mirrors(self) -> list[str]:
+        try:
+            if not self.cache_file.exists():
+                return []
+            data = json.loads(self.cache_file.read_text(encoding="utf-8"))
+            if time.time() - data.get("timestamp", 0) <= self.cache_ttl:
+                return [str(m).rstrip("/") for m in data.get("mirrors", []) if m]
+        except Exception:
+            return []
+        return []
+
+    def _save_cached_mirrors(self, mirrors: list[str]) -> None:
+        try:
+            self.cache_file.write_text(
+                json.dumps({"timestamp": time.time(), "mirrors": mirrors}, indent=2),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
+
+    @staticmethod
+    def _normalize_mirror(url: str) -> str:
+        normalized = url.strip().rstrip("/")
+        if not normalized.startswith(("http://", "https://")):
+            normalized = "https://" + normalized
+        return normalized
+
+    @staticmethod
+    def _dedupe(mirrors: list[str]) -> list[str]:
+        seen: set[str] = set()
+        unique: list[str] = []
+        for mirror in mirrors:
+            normalized = SciHubFetcher._normalize_mirror(mirror)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            unique.append(normalized)
+        return unique
 
     def _generate_filename(self, response: requests.Response, identifier: str) -> str:
         """Generate a unique filename for the PDF."""

--- a/paper_search_mcp/academic_platforms/sci_hub.py
+++ b/paper_search_mcp/academic_platforms/sci_hub.py
@@ -18,12 +18,13 @@ from ..config import get_env
 from ..utils import is_pdf_content
 
 
+DEFAULT_SCIHUB_MIRROR = "https://sci-hub.al"
+
 HARDCODED_MIRRORS = [
-    "https://sci-hub.se",
+    DEFAULT_SCIHUB_MIRROR,
     "https://sci-hub.st",
     "https://sci-hub.ru",
     "https://sci-hub.wf",
-    "https://sci-hub.al",
     "https://sci-hub.mk",
     "https://sci-hub.ee",
     "https://sci-hub.shop",
@@ -33,9 +34,9 @@ HARDCODED_MIRRORS = [
 class SciHubFetcher:
     """Simple Sci-Hub PDF downloader."""
 
-    def __init__(self, base_url: str = "https://sci-hub.se", output_dir: str = "./downloads"):
+    def __init__(self, base_url: Optional[str] = None, output_dir: str = "./downloads"):
         """Initialize with Sci-Hub URL and output directory."""
-        self.base_url = base_url.rstrip("/")
+        self.base_url = self._normalize_mirror(base_url) if base_url else ""
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.session = requests.Session()
@@ -206,19 +207,19 @@ class SciHubFetcher:
             for mirror in get_env("SCIHUB_MIRRORS", "").split(",")
             if mirror.strip()
         ]
-        candidates = configured or [self.base_url]
+        preferred = configured + ([self.base_url] if self.base_url else [])
 
         if not force_refresh:
             cached = self._load_cached_mirrors()
             if cached:
-                return self._dedupe(candidates + cached + HARDCODED_MIRRORS)
+                return self._dedupe(cached + preferred + HARDCODED_MIRRORS)
 
         discovered = self._discover_mirrors()
-        healthy = self._health_check(self._dedupe(candidates + discovered + HARDCODED_MIRRORS))
+        healthy = self._health_check(self._dedupe(discovered + preferred + HARDCODED_MIRRORS))
         if healthy:
             self._save_cached_mirrors(healthy)
             return healthy
-        return self._dedupe(candidates + HARDCODED_MIRRORS)
+        return self._dedupe(preferred + HARDCODED_MIRRORS)
 
     def _discover_mirrors(self) -> list[str]:
         """Fetch current Sci-Hub mirror candidates from public mirror lists."""

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -7,6 +7,7 @@ import time
 import random
 from ..paper import Paper
 from ..utils import extract_doi
+from ..utils import is_pdf_content
 from .base import PaperSource
 import logging
 from pypdf import PdfReader
@@ -380,6 +381,9 @@ class SemanticSearcher(PaperSource):
             pdf_url = paper.pdf_url
             pdf_response = requests.get(pdf_url, timeout=30)
             pdf_response.raise_for_status()
+            content_type = pdf_response.headers.get("content-type", "")
+            if not is_pdf_content(pdf_response.content, content_type=content_type, url=pdf_url):
+                return f"Error: Downloaded content is not a valid PDF for paper {paper_id}"
 
             # Create download directory if it doesn't exist
             os.makedirs(save_path, exist_ok=True)
@@ -425,6 +429,9 @@ class SemanticSearcher(PaperSource):
 
                 pdf_response = requests.get(paper.pdf_url, timeout=30)
                 pdf_response.raise_for_status()
+                content_type = pdf_response.headers.get("content-type", "")
+                if not is_pdf_content(pdf_response.content, content_type=content_type, url=paper.pdf_url):
+                    return f"Error: Downloaded content is not a valid PDF for paper {paper_id}"
 
                 with open(pdf_path, "wb") as f:
                     f.write(pdf_response.content)

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -161,8 +161,8 @@ class SemanticSearcher(PaperSource):
         """
         Make a request to the Semantic Scholar API with optional API key.
         """
-        max_retries = 3
         api_key = self.get_api_key()
+        max_retries = 3 if api_key else 1
         retry_delay = 5 if api_key is None else 2
         has_retried_without_key = False
 
@@ -188,6 +188,16 @@ class SemanticSearcher(PaperSource):
 
                 # 检查是否是429错误（限流）
                 if response.status_code == 429:
+                    if api_key is None:
+                        logger.warning(
+                            "Semantic Scholar anonymous access is rate-limited (429). "
+                            "Skipping retries; set SEMANTIC_SCHOLAR_API_KEY for higher limits."
+                        )
+                        return {
+                            "error": "rate_limited",
+                            "status_code": 429,
+                            "message": "Too many requests. Set SEMANTIC_SCHOLAR_API_KEY for higher limits.",
+                        }
                     if attempt < max_retries - 1:
                         retry_after = response.headers.get("Retry-After")
                         wait_time = (
@@ -226,6 +236,16 @@ class SemanticSearcher(PaperSource):
                     has_retried_without_key = True
                     continue
                 if e.response.status_code == 429:
+                    if api_key is None:
+                        logger.warning(
+                            "Semantic Scholar anonymous access is rate-limited (429). "
+                            "Skipping retries; set SEMANTIC_SCHOLAR_API_KEY for higher limits."
+                        )
+                        return {
+                            "error": "rate_limited",
+                            "status_code": 429,
+                            "message": "Too many requests. Set SEMANTIC_SCHOLAR_API_KEY for higher limits.",
+                        }
                     if attempt < max_retries - 1:
                         retry_after = e.response.headers.get("Retry-After")
                         wait_time = (

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -624,7 +624,7 @@ def build_parser() -> argparse.ArgumentParser:
                           help="Comma-separated sources, 'fastest', 'fast', or 'all' (default: fast)")
     p_search.add_argument("-y", "--year", default=None,
                           help="Year filter for Semantic Scholar (e.g. '2020', '2018-2022')")
-    p_search.add_argument("--source-timeout", type=float, default=12,
+    p_search.add_argument("--source-timeout", type=float, default=5,
                           help="Seconds before an individual source search times out (0 disables)")
     p_search.add_argument("--exhaustive", action="store_true",
                           help="Use the old broad source set when sources are omitted or set to 'all'")

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -220,6 +220,7 @@ def _score_recency(year: Optional[int]) -> int:
 
 def _score_metadata_record(merged: Dict[str, Any]) -> Dict[str, Any]:
     sources = merged.get("sources") or []
+    oa_pdf_sources = sorted(merged.get("oa_pdf_sources") or [])
     citations = max(0, int(merged.get("citations") or 0))
     title = str(merged.get("title") or "")
     abstract = str(merged.get("abstract") or "")
@@ -230,7 +231,7 @@ def _score_metadata_record(merged: Dict[str, Any]) -> Dict[str, Any]:
     source_coverage = min(100, len(sources) * 34)
     recency = _score_recency(_coerce_year(merged.get("published_date")))
     citation_signal = min(100, round(math.log10(citations + 1) / math.log10(1001) * 100)) if citations else 0
-    availability = 100 if _paper_has_content(merged, "pdf_url") or merged.get("oa_pdf_sources") else (45 if _paper_has_content(merged, "url") else 0)
+    availability = 100 if _paper_has_content(merged, "pdf_url") or oa_pdf_sources else (45 if _paper_has_content(merged, "url") else 0)
 
     metadata_confidence = 0
     metadata_confidence += 20 if _paper_has_content(merged, "title") else 0
@@ -276,7 +277,10 @@ def _score_metadata_record(merged: Dict[str, Any]) -> Dict[str, Any]:
     elif citations > 0:
         reasons.append(f"Citation signal available ({citations} citations)")
     if availability == 100:
-        reasons.append("Open access PDF available")
+        if oa_pdf_sources:
+            reasons.append(f"Open access PDF found via {', '.join(oa_pdf_sources)}")
+        else:
+            reasons.append("Open access PDF available")
     elif availability > 0:
         reasons.append("Landing page available")
     if len(sources) >= 2:

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -171,6 +171,16 @@ def _dedupe(papers: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return out
 
 
+def _strip_search_record(paper: Dict[str, Any], include_abstracts: bool) -> Dict[str, Any]:
+    if include_abstracts:
+        return paper
+    compact = dict(paper)
+    compact.pop("abstract", None)
+    compact.pop("references", None)
+    compact.pop("extra", None)
+    return compact
+
+
 def _extract_dois(values: list[str]) -> list[str]:
     seen: set[str] = set()
     dois: list[str] = []
@@ -462,7 +472,7 @@ async def cmd_search(args: argparse.Namespace) -> int:
                     p["source"] = name
                 merged.append(p)
 
-    deduped = _dedupe(merged)
+    deduped = [_strip_search_record(p, args.include_abstracts) for p in _dedupe(merged)]
 
     output = {
         "query": args.query,
@@ -619,13 +629,15 @@ def build_parser() -> argparse.ArgumentParser:
     # search
     p_search = sub.add_parser("search", help="Search for papers across academic platforms")
     p_search.add_argument("query", help="Search query")
-    p_search.add_argument("-n", "--max-results", type=int, default=5, help="Max results per source (default: 5)")
+    p_search.add_argument("-n", "--max-results", type=int, default=10, help="Max results per source (default: 10)")
     p_search.add_argument("-s", "--sources", default="fast",
                           help="Comma-separated sources, 'fastest', 'fast', or 'all' (default: fast)")
     p_search.add_argument("-y", "--year", default=None,
                           help="Year filter for Semantic Scholar (e.g. '2020', '2018-2022')")
     p_search.add_argument("--source-timeout", type=float, default=5,
                           help="Seconds before an individual source search times out (0 disables)")
+    p_search.add_argument("--include-abstracts", action="store_true",
+                          help="Include abstracts in search output. Omitted by default to keep agent context compact.")
     p_search.add_argument("--exhaustive", action="store_true",
                           help="Use the old broad source set when sources are omitted or set to 'all'")
 

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import re
 import sys
 from typing import Any, Dict, List
 
@@ -39,44 +40,58 @@ from .academic_platforms.ssrn import SSRNSearcher
 SEARCHERS: Dict[str, Any] = {}
 
 
-def _init_searchers() -> None:
-    """Lazily initialize searcher instances."""
-    if SEARCHERS:
-        return
+def _available_sources() -> list[str]:
+    sources = list(ALL_SOURCES)
+    if get_env("IEEE_API_KEY", ""):
+        sources.append("ieee")
+    if get_env("ACM_API_KEY", ""):
+        sources.append("acm")
+    return sources
 
-    SEARCHERS["arxiv"] = ArxivSearcher()
-    SEARCHERS["pubmed"] = PubMedSearcher()
-    SEARCHERS["biorxiv"] = BioRxivSearcher()
-    SEARCHERS["medrxiv"] = MedRxivSearcher()
-    SEARCHERS["google_scholar"] = GoogleScholarSearcher()
-    SEARCHERS["iacr"] = IACRSearcher()
-    SEARCHERS["semantic"] = SemanticSearcher()
-    SEARCHERS["crossref"] = CrossRefSearcher()
-    SEARCHERS["openalex"] = OpenAlexSearcher()
-    SEARCHERS["pmc"] = PMCSearcher()
-    SEARCHERS["core"] = CORESearcher()
-    SEARCHERS["europepmc"] = EuropePMCSearcher()
-    SEARCHERS["dblp"] = DBLPSearcher()
-    SEARCHERS["openaire"] = OpenAiresearcher()
-    SEARCHERS["citeseerx"] = CiteSeerXSearcher()
-    SEARCHERS["doaj"] = DOAJSearcher()
-    SEARCHERS["base"] = BASESearcher()
-    unpaywall_resolver = UnpaywallResolver()
-    SEARCHERS["unpaywall"] = UnpaywallSearcher(resolver=unpaywall_resolver)
-    SEARCHERS["zenodo"] = ZenodoSearcher()
-    SEARCHERS["hal"] = HALSearcher()
-    SEARCHERS["ssrn"] = SSRNSearcher()
 
-    # Optional paid connectors
-    ieee_key = get_env("IEEE_API_KEY", "")
-    if ieee_key:
+def _get_searcher(source: str) -> Any:
+    """Initialize only the searcher requested by the current command."""
+    if source in SEARCHERS:
+        return SEARCHERS[source]
+
+    factories = {
+        "arxiv": ArxivSearcher,
+        "pubmed": PubMedSearcher,
+        "biorxiv": BioRxivSearcher,
+        "medrxiv": MedRxivSearcher,
+        "google_scholar": GoogleScholarSearcher,
+        "iacr": IACRSearcher,
+        "semantic": SemanticSearcher,
+        "crossref": CrossRefSearcher,
+        "openalex": OpenAlexSearcher,
+        "pmc": PMCSearcher,
+        "core": CORESearcher,
+        "europepmc": EuropePMCSearcher,
+        "dblp": DBLPSearcher,
+        "openaire": OpenAiresearcher,
+        "citeseerx": CiteSeerXSearcher,
+        "doaj": DOAJSearcher,
+        "base": BASESearcher,
+        "zenodo": ZenodoSearcher,
+        "hal": HALSearcher,
+        "ssrn": SSRNSearcher,
+    }
+
+    if source == "unpaywall":
+        searcher = UnpaywallSearcher(resolver=UnpaywallResolver())
+    elif source == "ieee" and get_env("IEEE_API_KEY", ""):
         from .academic_platforms.ieee import IEEESearcher
-        SEARCHERS["ieee"] = IEEESearcher()
-
-    acm_key = get_env("ACM_API_KEY", "")
-    if acm_key:
+        searcher = IEEESearcher()
+    elif source == "acm" and get_env("ACM_API_KEY", ""):
         from .academic_platforms.acm import ACMSearcher
-        SEARCHERS["acm"] = ACMSearcher()
+        searcher = ACMSearcher()
+    elif source in factories:
+        searcher = factories[source]()
+    else:
+        raise KeyError(source)
+
+    SEARCHERS[source] = searcher
+    return searcher
 
 
 ALL_SOURCES = [
@@ -86,12 +101,45 @@ ALL_SOURCES = [
     "ssrn", "unpaywall",
 ]
 
+FASTEST_SOURCES = [
+    "openalex", "crossref",
+]
 
-def _parse_sources(sources: str) -> List[str]:
-    if not sources or sources.strip().lower() == "all":
-        return [s for s in ALL_SOURCES if s in SEARCHERS]
+FAST_SOURCES = [
+    "openalex", "crossref", "arxiv", "pubmed", "europepmc",
+]
+
+DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Z0-9]+\b", re.IGNORECASE)
+
+
+def _fast_sources() -> list[str]:
+    sources = list(FAST_SOURCES)
+    if get_env("SEMANTIC_SCHOLAR_API_KEY", ""):
+        sources.insert(2, "semantic")
+    return sources
+
+
+def _parse_sources(sources: str, exhaustive: bool = False) -> List[str]:
+    if not sources:
+        source_names = ALL_SOURCES if exhaustive else _fast_sources()
+        available = set(_available_sources())
+        return [s for s in source_names if s in available]
+
+    sources = sources.strip().lower()
+    if sources == "all":
+        source_names = ALL_SOURCES if exhaustive else _fast_sources()
+        available = set(_available_sources())
+        return [s for s in source_names if s in available]
+    if sources == "fast":
+        available = set(_available_sources())
+        return [s for s in _fast_sources() if s in available]
+    if sources == "fastest":
+        available = set(_available_sources())
+        return [s for s in FASTEST_SOURCES if s in available]
+
     normalized = [p.strip().lower() for p in sources.split(",") if p.strip()]
-    return [s for s in normalized if s in SEARCHERS]
+    available = set(_available_sources())
+    return [s for s in normalized if s in available]
 
 
 def _paper_unique_key(paper: Dict[str, Any]) -> str:
@@ -142,15 +190,16 @@ async def _with_timeout(coro: Any, timeout: float, label: str = "operation") -> 
 # ---------------------------------------------------------------------------
 
 async def cmd_search(args: argparse.Namespace) -> int:
-    _init_searchers()
-    selected = _parse_sources(args.sources)
+    selected = _parse_sources(args.sources, args.exhaustive)
+    if DOI_RE.search(args.query) and "unpaywall" not in selected and "unpaywall" in _available_sources():
+        selected.append("unpaywall")
     if not selected:
-        print(json.dumps({"error": "No valid sources selected", "available": sorted(SEARCHERS.keys())}))
+        print(json.dumps({"error": "No valid sources selected", "available": sorted(_available_sources())}))
         return 1
 
     tasks = {}
     for src in selected:
-        searcher = SEARCHERS[src]
+        searcher = _get_searcher(src)
         extra = {}
         if src == "semantic" and args.year:
             extra["year"] = args.year
@@ -183,6 +232,8 @@ async def cmd_search(args: argparse.Namespace) -> int:
     output = {
         "query": args.query,
         "sources_used": names,
+        "search_mode": "exhaustive" if args.exhaustive else "fast",
+        "source_preset": args.sources,
         "source_results": source_counts,
         "errors": errors,
         "total": len(deduped),
@@ -193,14 +244,13 @@ async def cmd_search(args: argparse.Namespace) -> int:
 
 
 async def cmd_download(args: argparse.Namespace) -> int:
-    _init_searchers()
     source = args.source.strip().lower()
 
-    if source not in SEARCHERS:
-        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(SEARCHERS.keys())}))
+    if source not in _available_sources():
+        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(_available_sources())}))
         return 1
 
-    searcher = SEARCHERS[source]
+    searcher = _get_searcher(source)
     try:
         result = await asyncio.to_thread(searcher.download_pdf, args.paper_id, args.save_path)
         print(json.dumps({"status": "ok", "path": result}))
@@ -232,14 +282,13 @@ async def cmd_download_doi(args: argparse.Namespace) -> int:
 
 
 async def cmd_read(args: argparse.Namespace) -> int:
-    _init_searchers()
     source = args.source.strip().lower()
 
-    if source not in SEARCHERS:
-        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(SEARCHERS.keys())}))
+    if source not in _available_sources():
+        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(_available_sources())}))
         return 1
 
-    searcher = SEARCHERS[source]
+    searcher = _get_searcher(source)
     try:
         text = await asyncio.to_thread(searcher.read_paper, args.paper_id, args.save_path)
         print(text)
@@ -250,8 +299,7 @@ async def cmd_read(args: argparse.Namespace) -> int:
 
 
 async def cmd_sources(args: argparse.Namespace) -> int:
-    _init_searchers()
-    print(json.dumps({"sources": sorted(SEARCHERS.keys())}, indent=2))
+    print(json.dumps({"sources": sorted(_available_sources())}, indent=2))
     return 0
 
 
@@ -270,12 +318,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_search = sub.add_parser("search", help="Search for papers across academic platforms")
     p_search.add_argument("query", help="Search query")
     p_search.add_argument("-n", "--max-results", type=int, default=5, help="Max results per source (default: 5)")
-    p_search.add_argument("-s", "--sources", default="all",
-                          help="Comma-separated sources or 'all' (default: all)")
+    p_search.add_argument("-s", "--sources", default="fast",
+                          help="Comma-separated sources, 'fastest', 'fast', or 'all' (default: fast)")
     p_search.add_argument("-y", "--year", default=None,
                           help="Year filter for Semantic Scholar (e.g. '2020', '2018-2022')")
-    p_search.add_argument("--source-timeout", type=float, default=30,
+    p_search.add_argument("--source-timeout", type=float, default=12,
                           help="Seconds before an individual source search times out (0 disables)")
+    p_search.add_argument("--exhaustive", action="store_true",
+                          help="Use the old broad source set when sources are omitted or set to 'all'")
 
     # download
     p_dl = sub.add_parser("download", help="Download a paper PDF")

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import math
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -188,6 +190,108 @@ def _paper_has_content(paper: Dict[str, Any], field: str) -> bool:
     return bool(value)
 
 
+def _coerce_year(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if hasattr(value, "year"):
+        try:
+            return int(value.year)
+        except (TypeError, ValueError):
+            return None
+    text = str(value)
+    match = re.search(r"\b(19|20)\d{2}\b", text)
+    return int(match.group(0)) if match else None
+
+
+def _score_recency(year: Optional[int]) -> int:
+    if not year:
+        return 0
+    age = max(0, datetime.now(timezone.utc).year - year)
+    if age <= 2:
+        return 100
+    if age <= 5:
+        return 80
+    if age <= 10:
+        return 60
+    if age <= 20:
+        return 35
+    return 15
+
+
+def _score_metadata_record(merged: Dict[str, Any]) -> Dict[str, Any]:
+    sources = merged.get("sources") or []
+    citations = max(0, int(merged.get("citations") or 0))
+    title = str(merged.get("title") or "")
+    abstract = str(merged.get("abstract") or "")
+    categories = str(merged.get("categories") or "")
+    keywords = str(merged.get("keywords") or "")
+    combined_text = " ".join([title, abstract, categories, keywords]).lower()
+
+    source_coverage = min(100, len(sources) * 34)
+    recency = _score_recency(_coerce_year(merged.get("published_date")))
+    citation_signal = min(100, round(math.log10(citations + 1) / math.log10(1001) * 100)) if citations else 0
+    availability = 100 if _paper_has_content(merged, "pdf_url") or merged.get("oa_pdf_sources") else (45 if _paper_has_content(merged, "url") else 0)
+
+    metadata_confidence = 0
+    metadata_confidence += 20 if _paper_has_content(merged, "title") else 0
+    metadata_confidence += 15 if _paper_has_content(merged, "authors") else 0
+    metadata_confidence += 25 if _paper_has_content(merged, "abstract") else 0
+    metadata_confidence += 15 if _paper_has_content(merged, "published_date") else 0
+    metadata_confidence += 10 if _paper_has_content(merged, "doi") else 0
+    metadata_confidence += 15 if _paper_has_content(merged, "categories") or _paper_has_content(merged, "keywords") else 0
+    metadata_confidence = min(100, metadata_confidence + min(20, len(sources) * 5))
+
+    review_terms = ["systematic review", "meta-analysis", "metaanalysis", "review", "synthesis", "survey"]
+    literature_fit = 45 if title else 20
+    if abstract:
+        literature_fit += 15
+    if any(term in combined_text for term in review_terms):
+        literature_fit += 40
+    literature_fit = min(100, literature_fit)
+
+    components = {
+        "literature_fit": literature_fit,
+        "recency": recency,
+        "citation_signal": citation_signal,
+        "availability": availability,
+        "metadata_confidence": metadata_confidence,
+    }
+    rank_score = round(
+        components["literature_fit"] * 0.25
+        + components["recency"] * 0.20
+        + components["citation_signal"] * 0.20
+        + components["availability"] * 0.15
+        + components["metadata_confidence"] * 0.20
+    )
+
+    reasons: list[str] = []
+    if any(term in combined_text for term in review_terms):
+        reasons.append("Review/synthesis keywords detected")
+    if recency >= 80:
+        reasons.append("Recent publication year")
+    elif recency == 0:
+        reasons.append("Publication year unavailable")
+    if citations >= 100:
+        reasons.append(f"Strong citation signal ({citations} citations)")
+    elif citations > 0:
+        reasons.append(f"Citation signal available ({citations} citations)")
+    if availability == 100:
+        reasons.append("Open access PDF available")
+    elif availability > 0:
+        reasons.append("Landing page available")
+    if len(sources) >= 2:
+        reasons.append(f"Metadata confirmed by {len(sources)} sources")
+    if metadata_confidence >= 80:
+        reasons.append("Rich title/abstract metadata")
+
+    return {
+        "rank_score": max(0, min(100, rank_score)),
+        "rank_reasons": reasons[:6],
+        "rank_components": components,
+        "source_coverage": source_coverage,
+    }
+
+
 def _merge_metadata_records(doi: str, records: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
     source_priority = ["crossref", "openalex", "semantic", "unpaywall"]
     merged: Dict[str, Any] = {
@@ -226,6 +330,7 @@ def _merge_metadata_records(doi: str, records: Dict[str, Dict[str, Any]]) -> Dic
         if _paper_has_content(paper, "pdf_url"):
             oa_sources.append(source)
     merged["oa_pdf_sources"] = sorted(oa_sources)
+    merged.update(_score_metadata_record(merged))
     return merged
 
 

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -7,6 +7,8 @@ import argparse
 import asyncio
 import json
 import math
+import multiprocessing as mp
+import queue
 import re
 import sys
 from datetime import datetime, timezone
@@ -109,7 +111,7 @@ FASTEST_SOURCES = [
 ]
 
 FAST_SOURCES = [
-    "openalex", "crossref", "pubmed", "europepmc",
+    "openalex", "crossref", "arxiv", "pubmed", "europepmc",
 ]
 
 DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Z0-9]+\b", re.IGNORECASE)
@@ -361,12 +363,53 @@ def _lookup_doi_with_source(source: str, doi: str) -> Optional[Dict[str, Any]]:
 # Async helpers
 # ---------------------------------------------------------------------------
 
-async def _async_search(searcher: Any, query: str, max_results: int, **kwargs) -> List[Dict]:
-    if kwargs:
-        papers = await asyncio.to_thread(searcher.search, query, max_results=max_results, **kwargs)
-    else:
-        papers = await asyncio.to_thread(searcher.search, query, max_results=max_results)
-    return [p.to_dict() for p in papers]
+def _search_source_worker(source: str, query_text: str, max_results: int, kwargs: Dict[str, Any], out_queue: Any) -> None:
+    try:
+        searcher = _get_searcher(source)
+        if kwargs:
+            papers = searcher.search(query_text, max_results=max_results, **kwargs)
+        else:
+            papers = searcher.search(query_text, max_results=max_results)
+        out_queue.put({"ok": True, "papers": [p.to_dict() for p in papers]})
+    except BaseException as exc:
+        out_queue.put({"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+
+
+def _run_search_source_process(source: str, query_text: str, max_results: int, timeout: float, **kwargs) -> List[Dict]:
+    method = "fork" if "fork" in mp.get_all_start_methods() else "spawn"
+    ctx = mp.get_context(method)
+    out_queue = ctx.Queue()
+    proc = ctx.Process(
+        target=_search_source_worker,
+        args=(source, query_text, max_results, kwargs, out_queue),
+        daemon=True,
+    )
+    proc.start()
+    proc.join(None if timeout <= 0 else timeout)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(1)
+        if proc.is_alive() and hasattr(proc, "kill"):
+            proc.kill()
+            proc.join(1)
+        raise TimeoutError(f"{source} timed out after {timeout:g}s")
+
+    try:
+        payload = out_queue.get_nowait()
+    except queue.Empty:
+        if proc.exitcode == 0:
+            return []
+        raise RuntimeError(f"{source} exited with code {proc.exitcode}")
+    finally:
+        out_queue.close()
+
+    if not payload.get("ok"):
+        raise RuntimeError(str(payload.get("error") or f"{source} failed"))
+    return payload.get("papers") or []
+
+
+async def _async_search_source(source: str, query: str, max_results: int, timeout: float, **kwargs) -> List[Dict]:
+    return await asyncio.to_thread(_run_search_source_process, source, query, max_results, timeout, **kwargs)
 
 
 async def _with_timeout(coro: Any, timeout: float, label: str = "operation") -> Any:
@@ -396,15 +439,10 @@ async def cmd_search(args: argparse.Namespace) -> int:
 
     tasks = {}
     for src in selected:
-        searcher = _get_searcher(src)
         extra = {}
         if src == "semantic" and args.year:
             extra["year"] = args.year
-        tasks[src] = _with_timeout(
-            _async_search(searcher, args.query, args.max_results, **extra),
-            args.source_timeout,
-            src,
-        )
+        tasks[src] = _async_search_source(src, args.query, args.max_results, args.source_timeout, **extra)
 
     names = list(tasks.keys())
     results = await asyncio.gather(*tasks.values(), return_exceptions=True)

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -290,7 +290,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_dl_doi.add_argument("--source", default="crossref", help="Primary source to try before fallbacks (default: crossref)")
     p_dl_doi.add_argument("--title", default="", help="Optional title for repository/Sci-Hub fallback")
     p_dl_doi.add_argument("--no-scihub", action="store_true", help="Disable Sci-Hub fallback")
-    p_dl_doi.add_argument("--scihub-base-url", default="https://sci-hub.se", help="Preferred Sci-Hub mirror")
+    p_dl_doi.add_argument("--scihub-base-url", default="", help="Preferred Sci-Hub mirror")
 
     # read
     p_read = sub.add_parser("read", help="Download and extract text from a paper")

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -128,6 +128,12 @@ async def _async_search(searcher: Any, query: str, max_results: int, **kwargs) -
     return [p.to_dict() for p in papers]
 
 
+async def _with_timeout(coro: Any, timeout: float) -> Any:
+    if timeout <= 0:
+        return await coro
+    return await asyncio.wait_for(coro, timeout=timeout)
+
+
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
@@ -145,7 +151,10 @@ async def cmd_search(args: argparse.Namespace) -> int:
         extra = {}
         if src == "semantic" and args.year:
             extra["year"] = args.year
-        tasks[src] = _async_search(searcher, args.query, args.max_results, **extra)
+        tasks[src] = _with_timeout(
+            _async_search(searcher, args.query, args.max_results, **extra),
+            args.source_timeout,
+        )
 
     names = list(tasks.keys())
     results = await asyncio.gather(*tasks.values(), return_exceptions=True)
@@ -197,6 +206,27 @@ async def cmd_download(args: argparse.Namespace) -> int:
         return 1
 
 
+async def cmd_download_doi(args: argparse.Namespace) -> int:
+    from .server import download_with_fallback
+
+    try:
+        result = await download_with_fallback(
+            source=args.source,
+            paper_id=args.doi,
+            doi=args.doi,
+            title=args.title or "",
+            save_path=args.save_path,
+            use_scihub=not args.no_scihub,
+            scihub_base_url=args.scihub_base_url,
+        )
+        status = "ok" if isinstance(result, str) and not result.lower().startswith("download failed") else "error"
+        print(json.dumps({"status": status, "path": result if status == "ok" else "", "message": "" if status == "ok" else result}))
+        return 0 if status == "ok" else 1
+    except Exception as e:
+        print(json.dumps({"status": "error", "message": str(e)}))
+        return 1
+
+
 async def cmd_read(args: argparse.Namespace) -> int:
     _init_searchers()
     source = args.source.strip().lower()
@@ -240,12 +270,23 @@ def build_parser() -> argparse.ArgumentParser:
                           help="Comma-separated sources or 'all' (default: all)")
     p_search.add_argument("-y", "--year", default=None,
                           help="Year filter for Semantic Scholar (e.g. '2020', '2018-2022')")
+    p_search.add_argument("--source-timeout", type=float, default=30,
+                          help="Seconds before an individual source search times out (0 disables)")
 
     # download
     p_dl = sub.add_parser("download", help="Download a paper PDF")
     p_dl.add_argument("source", help="Source platform (e.g. arxiv, semantic)")
     p_dl.add_argument("paper_id", help="Paper identifier")
     p_dl.add_argument("-o", "--save-path", default="./downloads", help="Save directory (default: ./downloads)")
+
+    # download-doi
+    p_dl_doi = sub.add_parser("download-doi", help="Download a DOI using source-native, OA, repository, and optional Sci-Hub fallback")
+    p_dl_doi.add_argument("doi", help="DOI to download")
+    p_dl_doi.add_argument("-o", "--save-path", default="./downloads", help="Save directory (default: ./downloads)")
+    p_dl_doi.add_argument("--source", default="crossref", help="Primary source to try before fallbacks (default: crossref)")
+    p_dl_doi.add_argument("--title", default="", help="Optional title for repository/Sci-Hub fallback")
+    p_dl_doi.add_argument("--no-scihub", action="store_true", help="Disable Sci-Hub fallback")
+    p_dl_doi.add_argument("--scihub-base-url", default="https://sci-hub.se", help="Preferred Sci-Hub mirror")
 
     # read
     p_read = sub.add_parser("read", help="Download and extract text from a paper")
@@ -266,6 +307,7 @@ def main() -> None:
     dispatch = {
         "search": cmd_search,
         "download": cmd_download,
+        "download-doi": cmd_download_doi,
         "read": cmd_read,
         "sources": cmd_sources,
     }

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -128,10 +128,13 @@ async def _async_search(searcher: Any, query: str, max_results: int, **kwargs) -
     return [p.to_dict() for p in papers]
 
 
-async def _with_timeout(coro: Any, timeout: float) -> Any:
+async def _with_timeout(coro: Any, timeout: float, label: str = "operation") -> Any:
     if timeout <= 0:
         return await coro
-    return await asyncio.wait_for(coro, timeout=timeout)
+    try:
+        return await asyncio.wait_for(coro, timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(f"{label} timed out after {timeout:g}s") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +157,7 @@ async def cmd_search(args: argparse.Namespace) -> int:
         tasks[src] = _with_timeout(
             _async_search(searcher, args.query, args.max_results, **extra),
             args.source_timeout,
+            src,
         )
 
     names = list(tasks.keys())

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -109,7 +109,7 @@ FASTEST_SOURCES = [
 ]
 
 FAST_SOURCES = [
-    "openalex", "crossref", "arxiv", "pubmed", "europepmc",
+    "openalex", "crossref", "pubmed", "europepmc",
 ]
 
 DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Z0-9]+\b", re.IGNORECASE)

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -8,7 +8,8 @@ import asyncio
 import json
 import re
 import sys
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from .config import get_env
 from .academic_platforms.arxiv import ArxivSearcher
@@ -111,6 +112,8 @@ FAST_SOURCES = [
 
 DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Z0-9]+\b", re.IGNORECASE)
 
+METADATA_SOURCES = ["crossref", "openalex", "unpaywall"]
+
 
 def _fast_sources() -> list[str]:
     sources = list(FAST_SOURCES)
@@ -164,6 +167,87 @@ def _dedupe(papers: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return out
 
 
+def _extract_dois(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    dois: list[str] = []
+    for value in values:
+        for match in DOI_RE.findall(value or ""):
+            doi = match.rstrip(".,;)]}").lower()
+            if doi and doi not in seen:
+                seen.add(doi)
+                dois.append(doi)
+    return dois
+
+
+def _paper_has_content(paper: Dict[str, Any], field: str) -> bool:
+    value = paper.get(field)
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return bool(value)
+
+
+def _merge_metadata_records(doi: str, records: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    source_priority = ["crossref", "openalex", "semantic", "unpaywall"]
+    merged: Dict[str, Any] = {
+        "doi": doi,
+        "title": "",
+        "authors": "",
+        "abstract": "",
+        "published_date": "",
+        "url": f"https://doi.org/{doi}",
+        "pdf_url": "",
+        "citations": 0,
+        "categories": "",
+        "keywords": "",
+        "sources": sorted(records.keys()),
+        "records": records,
+    }
+
+    for field in ["title", "authors", "abstract", "published_date", "url", "pdf_url", "categories", "keywords"]:
+        for source in source_priority:
+            paper = records.get(source)
+            if paper and _paper_has_content(paper, field):
+                merged[field] = paper[field]
+                break
+
+    citations = []
+    for paper in records.values():
+        try:
+            citations.append(int(paper.get("citations") or 0))
+        except (TypeError, ValueError):
+            pass
+    if citations:
+        merged["citations"] = max(citations)
+
+    oa_sources = []
+    for source, paper in records.items():
+        if _paper_has_content(paper, "pdf_url"):
+            oa_sources.append(source)
+    merged["oa_pdf_sources"] = sorted(oa_sources)
+    return merged
+
+
+def _lookup_doi_with_source(source: str, doi: str) -> Optional[Dict[str, Any]]:
+    searcher = _get_searcher(source)
+    paper = None
+
+    if source == "crossref":
+        paper = searcher.get_paper_by_doi(doi)
+    elif source == "openalex":
+        paper = searcher.get_paper_by_doi(doi)
+    elif source == "unpaywall":
+        paper = searcher.resolver.get_paper_by_doi(doi)
+    elif source == "semantic":
+        paper = searcher.get_paper_details(f"DOI:{doi}")
+    else:
+        results = searcher.search(doi, max_results=1)
+        paper = results[0] if results else None
+
+    return paper.to_dict() if paper else None
+
+
 # ---------------------------------------------------------------------------
 # Async helpers
 # ---------------------------------------------------------------------------
@@ -183,6 +267,10 @@ async def _with_timeout(coro: Any, timeout: float, label: str = "operation") -> 
         return await asyncio.wait_for(coro, timeout=timeout)
     except asyncio.TimeoutError as exc:
         raise TimeoutError(f"{label} timed out after {timeout:g}s") from exc
+
+
+async def _lookup_doi_source_async(source: str, doi: str) -> Optional[Dict[str, Any]]:
+    return await asyncio.to_thread(_lookup_doi_with_source, source, doi)
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +346,73 @@ async def cmd_download(args: argparse.Namespace) -> int:
     except Exception as e:
         print(json.dumps({"status": "error", "message": str(e)}))
         return 1
+
+
+async def cmd_metadata_dois(args: argparse.Namespace) -> int:
+    input_values = list(args.dois or [])
+    if args.input:
+        input_path = Path(args.input)
+        input_values.extend(input_path.read_text().splitlines())
+
+    dois = _extract_dois(input_values)
+    if not dois:
+        print(json.dumps({"error": "No DOI values found", "metadata": []}, indent=2))
+        return 1
+
+    sources = _parse_sources(args.sources)
+    if args.sources == "metadata":
+        sources = [s for s in METADATA_SOURCES if s in _available_sources()]
+    if args.include_semantic or get_env("SEMANTIC_SCHOLAR_API_KEY", ""):
+        if "semantic" in _available_sources() and "semantic" not in sources:
+            sources.append("semantic")
+    if not sources:
+        print(json.dumps({"error": "No valid sources selected", "available": sorted(_available_sources())}, indent=2))
+        return 1
+
+    doi_outputs: list[Dict[str, Any]] = []
+    for doi in dois:
+        tasks = {
+            source: _with_timeout(
+                _lookup_doi_source_async(source, doi),
+                args.source_timeout,
+                f"{source}:{doi}",
+            )
+            for source in sources
+        }
+        results = await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+        records: Dict[str, Dict[str, Any]] = {}
+        errors: Dict[str, str] = {}
+        for source, result in zip(tasks.keys(), results):
+            if isinstance(result, Exception):
+                errors[source] = str(result)
+            elif result:
+                records[source] = result
+
+        doi_outputs.append(
+            {
+                "doi": doi,
+                "sources_used": list(tasks.keys()),
+                "source_results": {source: source in records for source in tasks.keys()},
+                "errors": errors,
+                "metadata": _merge_metadata_records(doi, records) if records else None,
+            }
+        )
+
+    output = {
+        "dois": dois,
+        "sources_used": sources,
+        "total": len(doi_outputs),
+        "results": doi_outputs,
+    }
+
+    text = json.dumps(output, indent=2, default=str)
+    if args.output:
+        Path(args.output).write_text(text + "\n")
+        print(json.dumps({"status": "ok", "path": args.output, "total": len(doi_outputs)}, indent=2))
+    else:
+        print(text)
+    return 0
 
 
 async def cmd_download_doi(args: argparse.Namespace) -> int:
@@ -342,6 +497,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_dl_doi.add_argument("--no-scihub", action="store_true", help="Disable Sci-Hub fallback")
     p_dl_doi.add_argument("--scihub-base-url", default="", help="Preferred Sci-Hub mirror")
 
+    # metadata-dois
+    p_meta = sub.add_parser("metadata-dois", help="Fetch and merge metadata for one or more DOIs")
+    p_meta.add_argument("dois", nargs="*", help="DOIs or text containing DOIs")
+    p_meta.add_argument("-i", "--input", help="Text file containing DOI values")
+    p_meta.add_argument("-o", "--output", help="Write JSON output to this file")
+    p_meta.add_argument("-s", "--sources", default="metadata",
+                        help="Comma-separated sources or 'metadata' (default: metadata = crossref,openalex,unpaywall)")
+    p_meta.add_argument("--include-semantic", action="store_true",
+                        help="Include Semantic Scholar even without SEMANTIC_SCHOLAR_API_KEY")
+    p_meta.add_argument("--source-timeout", type=float, default=12,
+                        help="Seconds before an individual source lookup times out (0 disables)")
+
     # read
     p_read = sub.add_parser("read", help="Download and extract text from a paper")
     p_read.add_argument("source", help="Source platform (e.g. arxiv, semantic)")
@@ -361,6 +528,7 @@ def main() -> None:
     dispatch = {
         "search": cmd_search,
         "download": cmd_download,
+        "metadata-dois": cmd_metadata_dois,
         "download-doi": cmd_download_doi,
         "read": cmd_read,
         "sources": cmd_sources,

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -26,6 +26,7 @@ from .academic_platforms.citeseerx import CiteSeerXSearcher
 from .academic_platforms.doaj import DOAJSearcher
 from .academic_platforms.base_search import BASESearcher
 from .academic_platforms.unpaywall import UnpaywallResolver, UnpaywallSearcher
+from .utils import is_pdf_content
 from .academic_platforms.zenodo import ZenodoSearcher
 from .academic_platforms.hal import HALSearcher
 from .academic_platforms.ssrn import SSRNSearcher
@@ -184,9 +185,8 @@ async def _download_from_url(pdf_url: str, save_path: str, filename_hint: str = 
         if response.status_code >= 400 or not response.content:
             return None
 
-        content_type = (response.headers.get("content-type") or "").lower()
-        is_pdf = "pdf" in content_type or response.content.startswith(b"%PDF") or pdf_url.lower().endswith(".pdf")
-        if not is_pdf:
+        content_type = response.headers.get("content-type") or ""
+        if not is_pdf_content(response.content, content_type=content_type, url=pdf_url):
             logger.warning("Resolved URL is not a PDF candidate: %s (content-type=%s)", pdf_url, content_type)
             return None
 
@@ -230,7 +230,7 @@ async def _try_repository_fallback(doi: str, title: str, save_path: str) -> tupl
                 if not pdf_url:
                     continue
 
-                paper_id = (getattr(paper, "paper_id", "") or query).strip()
+                paper_id = str(getattr(paper, "paper_id", "") or query).strip()
                 downloaded = await _download_from_url(pdf_url, save_path, f"{repo_name}_{paper_id}")
                 if downloaded:
                     return downloaded, ""

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -748,7 +748,7 @@ async def download_crossref(paper_id: str, save_path: str = "./downloads") -> st
 async def download_scihub(
     identifier: str,
     save_path: str = "./downloads",
-    base_url: str = "https://sci-hub.se",
+    base_url: str = "",
 ) -> str:
     """Download paper PDF via Sci-Hub (optional fallback connector).
 
@@ -774,7 +774,7 @@ async def download_with_fallback(
     title: str = "",
     save_path: str = "./downloads",
     use_scihub: bool = True,
-    scihub_base_url: str = "https://sci-hub.se",
+    scihub_base_url: str = "",
 ) -> str:
     """Try source-native download, OA repositories, Unpaywall, then optional Sci-Hub.
 

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -814,12 +814,6 @@ async def download_with_fallback(
     if primary_error:
         attempt_errors.append(f"primary: {primary_error}")
 
-    repository_result, repository_error = await _try_repository_fallback(doi, title, save_path)
-    if repository_result:
-        return repository_result
-    if repository_error:
-        attempt_errors.append(f"repositories: {repository_error}")
-
     normalized_doi = (doi or "").strip()
     if normalized_doi:
         unpaywall_url = await asyncio.to_thread(unpaywall_resolver.resolve_best_pdf_url, normalized_doi)
@@ -832,6 +826,12 @@ async def download_with_fallback(
             attempt_errors.append("unpaywall: no OA URL found (or PAPER_SEARCH_MCP_UNPAYWALL_EMAIL/UNPAYWALL_EMAIL missing)")
     else:
         attempt_errors.append("unpaywall: DOI not provided")
+
+    repository_result, repository_error = await _try_repository_fallback(doi, title, save_path)
+    if repository_result:
+        return repository_result
+    if repository_error:
+        attempt_errors.append(f"repositories: {repository_error}")
 
     if not use_scihub:
         return "Download failed after OA fallback chain. Details: " + " | ".join(attempt_errors)

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -77,6 +77,15 @@ async def async_search(searcher, query: str, max_results: int, **kwargs) -> List
     return [paper.to_dict() for paper in papers]
 
 
+async def _with_source_timeout(source: str, coro: Any, timeout: float) -> Any:
+    if timeout <= 0:
+        return await coro
+    try:
+        return await asyncio.wait_for(coro, timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(f"{source} timed out after {timeout:g}s") from exc
+
+
 ALL_SOURCES = [
     "arxiv",
     "pubmed",
@@ -244,6 +253,7 @@ async def search_papers(
     max_results_per_source: int = 5,
     sources: str = "all",
     year: Optional[str] = None,
+    source_timeout: float = 30,
 ) -> Dict[str, Any]:
     """Unified top-level search across all configured academic platforms.
 
@@ -321,7 +331,11 @@ async def search_papers(
                 task_map[source] = async_search(acm_searcher, query, max_results_per_source)
 
     source_names = list(task_map.keys())
-    source_outputs = await asyncio.gather(*task_map.values(), return_exceptions=True)
+    timed_tasks = [
+        _with_source_timeout(source_name, task_map[source_name], source_timeout)
+        for source_name in source_names
+    ]
+    source_outputs = await asyncio.gather(*timed_tasks, return_exceptions=True)
 
     source_results: Dict[str, int] = {}
     errors: Dict[str, str] = {}

--- a/paper_search_mcp/utils.py
+++ b/paper_search_mcp/utils.py
@@ -6,3 +6,17 @@ def extract_doi(text: str) -> str:
         return ""
     match = re.search(r"10\.\d{4,9}/[-._;()/:A-Z0-9]+", text, re.IGNORECASE)
     return match.group(0).rstrip(".,;)") if match else ""
+
+
+def is_pdf_content(content: bytes, content_type: str = "", url: str = "") -> bool:
+    """Return True when bytes look like a real PDF response."""
+    if not content:
+        return False
+
+    lowered_type = (content_type or "").lower()
+    lowered_url = (url or "").lower()
+    return (
+        content.startswith(b"%PDF")
+        or "pdf" in lowered_type
+        or lowered_url.endswith(".pdf")
+    )

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -78,6 +78,29 @@ class TestDownloadWithFallback(unittest.TestCase):
         with self.assertRaises(asyncio.TimeoutError):
             asyncio.run(cli._with_timeout(slow_result(), 0.01))
 
+    def test_parse_sources_defaults_to_fast_set(self):
+        cli.SEARCHERS.clear()
+        selected = cli._parse_sources("fast")
+        self.assertEqual(selected, [s for s in cli._fast_sources() if s in cli._available_sources()])
+        self.assertEqual(cli.SEARCHERS, {})
+
+        fastest = cli._parse_sources("fastest")
+        self.assertEqual(fastest, [s for s in cli.FASTEST_SOURCES if s in cli._available_sources()])
+        self.assertLess(len(fastest), len(selected))
+
+        selected_from_all = cli._parse_sources("all")
+        self.assertEqual(selected_from_all, selected)
+
+        exhaustive = cli._parse_sources("all", exhaustive=True)
+        self.assertIn("google_scholar", exhaustive)
+        self.assertGreater(len(exhaustive), len(selected))
+
+    def test_fast_sources_include_semantic_when_key_is_configured(self):
+        with patch.dict("os.environ", {"PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY": "test-key"}):
+            selected = cli._parse_sources("fast")
+
+        self.assertIn("semantic", selected)
+
     def test_download_doi_cli_uses_fallback(self):
         args = SimpleNamespace(
             doi="10.1000/test",

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -224,6 +224,51 @@ class TestDownloadWithFallback(unittest.TestCase):
             self.assertGreaterEqual(score, 0)
             self.assertLessEqual(score, 100)
 
+    def test_metadata_dois_scores_pdf_availability_from_unpaywall(self):
+        base_record = {
+            "doi": "10.1000/unpaywall-only",
+            "title": "Ecological model evaluation",
+            "authors": "Ada Lovelace",
+            "abstract": "A paper about model evaluation.",
+            "published_date": "2024-01-01",
+            "url": "https://doi.org/10.1000/unpaywall-only",
+            "pdf_url": "",
+            "citations": 12,
+            "categories": "Ecology",
+            "keywords": "models",
+        }
+        crossref_record = dict(base_record, source="crossref")
+        openalex_record = dict(base_record, source="openalex")
+        unpaywall_record = dict(base_record, source="unpaywall", pdf_url="https://example.org/oa.pdf")
+
+        crossref = SimpleNamespace(get_paper_by_doi=lambda doi: SimpleNamespace(to_dict=lambda: crossref_record))
+        openalex = SimpleNamespace(get_paper_by_doi=lambda doi: SimpleNamespace(to_dict=lambda: openalex_record))
+        unpaywall = SimpleNamespace(resolver=SimpleNamespace(get_paper_by_doi=lambda doi: SimpleNamespace(to_dict=lambda: unpaywall_record)))
+
+        def fake_get_searcher(source):
+            return {"crossref": crossref, "openalex": openalex, "unpaywall": unpaywall}[source]
+
+        args = SimpleNamespace(
+            dois=["10.1000/unpaywall-only"],
+            input=None,
+            output=None,
+            sources="metadata",
+            include_semantic=False,
+            source_timeout=2,
+        )
+
+        stdout = io.StringIO()
+        with patch.object(cli, "_get_searcher", side_effect=fake_get_searcher), \
+             patch.object(cli, "_available_sources", return_value=["crossref", "openalex", "unpaywall"]), \
+             redirect_stdout(stdout):
+            result = asyncio.run(cli.cmd_metadata_dois(args))
+
+        self.assertEqual(result, 0)
+        metadata = json.loads(stdout.getvalue())["results"][0]["metadata"]
+        self.assertEqual(metadata["rank_components"]["availability"], 100)
+        self.assertEqual(metadata["oa_pdf_sources"], ["unpaywall"])
+        self.assertTrue(any("unpaywall" in reason.lower() for reason in metadata["rank_reasons"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, AsyncMock
 from types import SimpleNamespace
 
 from paper_search_mcp import server
+from paper_search_mcp import cli
 
 
 class TestDownloadWithFallback(unittest.TestCase):
@@ -68,6 +69,28 @@ class TestDownloadWithFallback(unittest.TestCase):
         self.assertEqual(result, "/tmp/repo.pdf")
         self.assertEqual(error, "")
         self.assertEqual(download.call_args.args[2], "openaire_12345")
+
+    def test_search_source_timeout_is_reported(self):
+        async def slow_result():
+            await asyncio.sleep(1)
+            return []
+
+        with self.assertRaises(asyncio.TimeoutError):
+            asyncio.run(cli._with_timeout(slow_result(), 0.01))
+
+    def test_download_doi_cli_uses_fallback(self):
+        args = SimpleNamespace(
+            doi="10.1000/test",
+            source="crossref",
+            title="",
+            save_path="/tmp",
+            no_scihub=True,
+            scihub_base_url="https://sci-hub.se",
+        )
+        with patch("paper_search_mcp.server.download_with_fallback", new=AsyncMock(return_value="/tmp/paper.pdf")):
+            result = asyncio.run(cli.cmd_download_doi(args))
+
+        self.assertEqual(result, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,6 +1,7 @@
 import unittest
 import asyncio
 from unittest.mock import patch, AsyncMock
+from types import SimpleNamespace
 
 from paper_search_mcp import server
 
@@ -51,6 +52,21 @@ class TestDownloadWithFallback(unittest.TestCase):
                 )
             )
             self.assertIn("OA fallback chain", result)
+
+    def test_repository_fallback_handles_numeric_paper_id(self):
+        paper = SimpleNamespace(paper_id=12345, pdf_url="https://example.org/paper.pdf")
+        searcher = SimpleNamespace(search=lambda query, max_results=3: [paper])
+
+        with patch.object(server, "openaire_searcher", searcher), \
+             patch.object(server, "core_searcher", SimpleNamespace(search=lambda *args, **kwargs: [])), \
+             patch.object(server, "europepmc_searcher", SimpleNamespace(search=lambda *args, **kwargs: [])), \
+             patch.object(server, "pmc_searcher", SimpleNamespace(search=lambda *args, **kwargs: [])), \
+             patch("paper_search_mcp.server._download_from_url", new=AsyncMock(return_value="/tmp/repo.pdf")) as download:
+            result, error = asyncio.run(server._try_repository_fallback("10.1000/test", "title", "/tmp"))
+
+        self.assertEqual(result, "/tmp/repo.pdf")
+        self.assertEqual(error, "")
+        self.assertEqual(download.call_args.args[2], "openaire_12345")
 
 
 if __name__ == "__main__":

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -9,6 +9,7 @@ from paper_search_mcp import server
 class TestDownloadWithFallback(unittest.TestCase):
     def test_repository_fallback_before_scihub(self):
         with patch.object(server.arxiv_searcher, "download_pdf", side_effect=Exception("primary failed")), \
+             patch.object(server.unpaywall_resolver, "resolve_best_pdf_url", return_value=None), \
              patch("paper_search_mcp.server._try_repository_fallback", new=AsyncMock(return_value=("/tmp/repo.pdf", ""))), \
              patch("paper_search_mcp.server.SciHubFetcher.download_pdf", side_effect=AssertionError("Sci-Hub should not be called")):
             result = asyncio.run(
@@ -22,9 +23,9 @@ class TestDownloadWithFallback(unittest.TestCase):
             )
             self.assertEqual(result, "/tmp/repo.pdf")
 
-    def test_unpaywall_fallback_after_repositories(self):
+    def test_unpaywall_fallback_before_repositories(self):
         with patch.object(server.arxiv_searcher, "download_pdf", side_effect=Exception("primary failed")), \
-             patch("paper_search_mcp.server._try_repository_fallback", new=AsyncMock(return_value=(None, "repo failed"))), \
+             patch("paper_search_mcp.server._try_repository_fallback", new=AsyncMock(side_effect=AssertionError("repositories should not be called"))), \
              patch.object(server.unpaywall_resolver, "resolve_best_pdf_url", return_value="https://example.org/oa.pdf"), \
              patch("paper_search_mcp.server._download_from_url", new=AsyncMock(return_value="/tmp/unpaywall.pdf")):
             result = asyncio.run(

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,5 +1,8 @@
 import unittest
 import asyncio
+import io
+import json
+from contextlib import redirect_stdout
 from unittest.mock import patch, AsyncMock
 from types import SimpleNamespace
 
@@ -168,6 +171,58 @@ class TestDownloadWithFallback(unittest.TestCase):
             result = asyncio.run(cli.cmd_metadata_dois(args))
 
         self.assertEqual(result, 0)
+
+    def test_metadata_dois_adds_rank_fields_from_available_metadata(self):
+        review_record = {
+            "doi": "10.1000/review",
+            "title": "A systematic review of ecological forecasting",
+            "authors": "Ada Lovelace; Grace Hopper",
+            "abstract": "This review synthesizes ecological forecasting studies.",
+            "published_date": "2025-02-03",
+            "url": "https://doi.org/10.1000/review",
+            "pdf_url": "https://example.org/review.pdf",
+            "citations": 125,
+            "categories": "Ecology",
+            "keywords": "forecasting; systematic review",
+            "source": "openalex",
+        }
+        crossref_record = dict(review_record, source="crossref", pdf_url="", citations=80)
+
+        crossref = SimpleNamespace(get_paper_by_doi=lambda doi: SimpleNamespace(to_dict=lambda: crossref_record))
+        openalex = SimpleNamespace(get_paper_by_doi=lambda doi: SimpleNamespace(to_dict=lambda: review_record))
+        unpaywall = SimpleNamespace(resolver=SimpleNamespace(get_paper_by_doi=lambda doi: None))
+
+        def fake_get_searcher(source):
+            return {"crossref": crossref, "openalex": openalex, "unpaywall": unpaywall}[source]
+
+        args = SimpleNamespace(
+            dois=["10.1000/review"],
+            input=None,
+            output=None,
+            sources="metadata",
+            include_semantic=False,
+            source_timeout=2,
+        )
+
+        stdout = io.StringIO()
+        with patch.object(cli, "_get_searcher", side_effect=fake_get_searcher), \
+             patch.object(cli, "_available_sources", return_value=["crossref", "openalex", "unpaywall"]), \
+             redirect_stdout(stdout):
+            result = asyncio.run(cli.cmd_metadata_dois(args))
+
+        self.assertEqual(result, 0)
+        metadata = json.loads(stdout.getvalue())["results"][0]["metadata"]
+        self.assertGreaterEqual(metadata["rank_score"], 80)
+        self.assertIn("rank_reasons", metadata)
+        self.assertTrue(any("review" in reason.lower() for reason in metadata["rank_reasons"]))
+        self.assertTrue(any("open access" in reason.lower() or "pdf" in reason.lower() for reason in metadata["rank_reasons"]))
+        self.assertEqual(
+            sorted(metadata["rank_components"]),
+            ["availability", "citation_signal", "literature_fit", "metadata_confidence", "recency"],
+        )
+        for score in metadata["rank_components"].values():
+            self.assertGreaterEqual(score, 0)
+            self.assertLessEqual(score, 100)
 
 
 if __name__ == "__main__":

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -115,6 +115,60 @@ class TestDownloadWithFallback(unittest.TestCase):
 
         self.assertEqual(result, 0)
 
+    def test_metadata_dois_merges_parallel_source_results(self):
+        crossref_paper = SimpleNamespace(
+            to_dict=lambda: {
+                "doi": "10.1000/test",
+                "title": "Crossref Title",
+                "authors": "Ada Lovelace",
+                "abstract": "",
+                "published_date": "2024-01-01T00:00:00",
+                "url": "https://doi.org/10.1000/test",
+                "pdf_url": "",
+                "citations": 0,
+                "categories": "",
+                "keywords": "",
+                "source": "crossref",
+            }
+        )
+        openalex_paper = SimpleNamespace(
+            to_dict=lambda: {
+                "doi": "10.1000/test",
+                "title": "OpenAlex Title",
+                "authors": "Ada Lovelace; Grace Hopper",
+                "abstract": "Useful abstract",
+                "published_date": "",
+                "url": "https://openalex.org/W1",
+                "pdf_url": "https://example.org/paper.pdf",
+                "citations": 42,
+                "categories": "Ecology",
+                "keywords": "",
+                "source": "openalex",
+            }
+        )
+
+        crossref = SimpleNamespace(get_paper_by_doi=lambda doi: crossref_paper)
+        openalex = SimpleNamespace(get_paper_by_doi=lambda doi: openalex_paper)
+        unpaywall = SimpleNamespace(resolver=SimpleNamespace(get_paper_by_doi=lambda doi: None))
+
+        def fake_get_searcher(source):
+            return {"crossref": crossref, "openalex": openalex, "unpaywall": unpaywall}[source]
+
+        args = SimpleNamespace(
+            dois=["10.1000/test"],
+            input=None,
+            output=None,
+            sources="metadata",
+            include_semantic=False,
+            source_timeout=2,
+        )
+
+        with patch.object(cli, "_get_searcher", side_effect=fake_get_searcher), \
+             patch.object(cli, "_available_sources", return_value=["crossref", "openalex", "unpaywall"]):
+            result = asyncio.run(cli.cmd_metadata_dois(args))
+
+        self.assertEqual(result, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pdf_validation.py
+++ b/tests/test_pdf_validation.py
@@ -1,0 +1,18 @@
+import unittest
+
+from paper_search_mcp.utils import is_pdf_content
+
+
+class TestPdfValidation(unittest.TestCase):
+    def test_empty_content_is_not_pdf(self):
+        self.assertFalse(is_pdf_content(b"", content_type="application/pdf"))
+
+    def test_pdf_magic_is_valid(self):
+        self.assertTrue(is_pdf_content(b"%PDF-1.7\n...", content_type="application/octet-stream"))
+
+    def test_pdf_content_type_is_valid(self):
+        self.assertTrue(is_pdf_content(b"content", content_type="application/pdf"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sci_hub.py
+++ b/tests/test_sci_hub.py
@@ -12,7 +12,7 @@ def check_sci_hub_accessible():
     """Check if Sci-Hub is accessible"""
     try:
         # Test with a simple request to see if sci-hub responds
-        response = requests.get("https://sci-hub.se", timeout=10)
+        response = requests.get("https://sci-hub.al", timeout=10)
         return response.status_code == 200
     except:
         return False
@@ -37,7 +37,7 @@ class TestSciHubFetcher(unittest.TestCase):
 
     def test_init(self):
         """Test initialization of SciHubFetcher"""
-        self.assertEqual(self.fetcher.base_url, "https://sci-hub.se")
+        self.assertEqual(self.fetcher.base_url, "")
         self.assertTrue(os.path.exists(self.test_dir))
         self.assertIsNotNone(self.fetcher.session)
 
@@ -149,8 +149,7 @@ class TestSciHubFetcher(unittest.TestCase):
     def test_candidate_mirrors_use_cache_before_hardcoded(self):
         self.fetcher._save_cached_mirrors(["https://sci-hub.al"])
         mirrors = self.fetcher.get_candidate_mirrors()
-        self.assertEqual(mirrors[0], "https://sci-hub.se")
-        self.assertEqual(mirrors[1], "https://sci-hub.al")
+        self.assertEqual(mirrors[0], "https://sci-hub.al")
 
     def test_download_tries_next_mirror_when_default_fails(self):
         self.fetcher.get_candidate_mirrors = Mock(return_value=[

--- a/tests/test_sci_hub.py
+++ b/tests/test_sci_hub.py
@@ -4,6 +4,7 @@ import tempfile
 import shutil
 import os
 import requests
+from unittest.mock import Mock, patch
 from paper_search_mcp.academic_platforms.sci_hub import SciHubFetcher
 
 
@@ -127,6 +128,50 @@ class TestSciHubFetcher(unittest.TestCase):
         pdf_url = "https://example.com/paper.pdf"
         result = self.fetcher._get_direct_url(pdf_url)
         self.assertEqual(result, pdf_url)
+
+    def test_discover_mirrors_from_now_sh_html(self):
+        response = Mock()
+        response.text = """
+        <html>
+          <a href="https://sci-hub.al">mirror</a>
+          <p>sci-hub.st sci-hub.ru</p>
+        </html>
+        """
+        response.raise_for_status.return_value = None
+
+        with patch.object(self.fetcher.session, "get", return_value=response):
+            mirrors = self.fetcher._discover_mirrors()
+
+        self.assertIn("https://sci-hub.al", mirrors)
+        self.assertIn("https://sci-hub.st", mirrors)
+        self.assertIn("https://sci-hub.ru", mirrors)
+
+    def test_candidate_mirrors_use_cache_before_hardcoded(self):
+        self.fetcher._save_cached_mirrors(["https://sci-hub.al"])
+        mirrors = self.fetcher.get_candidate_mirrors()
+        self.assertEqual(mirrors[0], "https://sci-hub.se")
+        self.assertEqual(mirrors[1], "https://sci-hub.al")
+
+    def test_download_tries_next_mirror_when_default_fails(self):
+        self.fetcher.get_candidate_mirrors = Mock(return_value=[
+            "https://sci-hub.se",
+            "https://sci-hub.al",
+        ])
+
+        with patch.object(self.fetcher, "_get_direct_url", side_effect=[None, "https://example.org/paper.pdf"]) as direct_url, \
+             patch.object(self.fetcher.session, "get") as get:
+            response = Mock()
+            response.status_code = 200
+            response.content = b"%PDF-1.4 fake"
+            response.headers = {"Content-Type": "application/pdf"}
+            response.url = "https://example.org/paper.pdf"
+            get.return_value = response
+
+            result = self.fetcher.download_pdf("10.1000/test")
+
+        self.assertIsNotNone(result)
+        self.assertTrue(os.path.exists(result))
+        self.assertEqual(direct_url.call_count, 2)
 
     @unittest.skipUnless(check_sci_hub_accessible(), "Sci-Hub not accessible")
     def test_get_direct_url_doi(self):

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -64,6 +64,18 @@ class TestSemanticSearcher(unittest.TestCase):
         self.assertIsNotNone(paper)
         self.assertIsNone(paper.published_date)
 
+    def test_anonymous_rate_limit_fails_fast(self):
+        response = Mock()
+        response.status_code = 429
+        response.headers = {}
+
+        with patch.object(self.searcher, "get_api_key", return_value=None), \
+             patch.object(self.searcher.session, "get", return_value=response) as get:
+            result = self.searcher.request_api("paper/search", {"query": "test"})
+
+        self.assertEqual(result["error"], "rate_limited")
+        self.assertEqual(get.call_count, 1)
+
     @unittest.skipUnless(check_semantic_accessible(), "Semantic Scholar not accessible")
     def test_search_basic(self):
         """Test basic search functionality"""


### PR DESCRIPTION
## Summary

This PR improves DOI/PDF download robustness and makes the fallback path more practical from the CLI.

Changes are intentionally split into small commits:

1. Validate fallback PDF downloads
   - Fixes a crash when repository searchers return numeric `paper_id` values.
   - Adds shared PDF response validation so empty/non-PDF responses are not reported as successful downloads.
   - Applies validation to Semantic Scholar downloads.

2. Discover working Sci-Hub mirrors
   - Adds optional dynamic Sci-Hub mirror discovery from `sci-hub.now.sh`.
   - Adds mirror health probing, latency sorting, and a 6h cache.
   - Preserves custom/preferred mirrors and hardcoded fallbacks.
   - Credits the MIT-licensed `OpenByteDev/scihub-scraper-cli` project for the mirror discovery idea.

3. Prefer Unpaywall before repository fallbacks
   - When a DOI is available, tries Unpaywall before slower repository searches.
   - This avoids unnecessary repository delays and lets the clean OA path win quickly.

4. Add DOI fallback CLI and source search timeouts
   - Adds `paper-search download-doi <doi>` for source-native -> Unpaywall -> repositories -> optional Sci-Hub fallback from the CLI.
   - Adds `--source-timeout` for search so slow providers do not hang the entire search.

5. Report source search timeouts
   - Makes timeout errors explicit, e.g. `google_scholar timed out after 2s`.

## Why

While comparing this project against a narrower DOI-downloader, I found a few reproducible issues:

- `download_with_fallback` could crash before reaching Unpaywall if a repository result had a numeric `paper_id`.
- `paper-search download semantic DOI:...` could report success while writing an empty 0-byte PDF.
- The default Sci-Hub mirror (`sci-hub.se`) can fail DNS while another mirror works.
- The CLI did not expose the useful `download_with_fallback` flow for users who only have a DOI.
- Slow providers such as Google Scholar can make broad search feel stuck.

## Verification

Ran:

```bash
python -m pytest tests/test_fallback.py tests/test_pdf_validation.py tests/test_sci_hub.py tests/test_unpaywall.py tests/test_unpaywall_source.py
python -m py_compile paper_search_mcp/cli.py paper_search_mcp/server.py paper_search_mcp/academic_platforms/sci_hub.py paper_search_mcp/academic_platforms/semantic.py paper_search_mcp/utils.py
```

Result: `27 passed, 4 skipped` for the focused pytest suite.

Live smoke checks:

```bash
PAPER_SEARCH_MCP_UNPAYWALL_EMAIL=... paper-search download-doi 10.1038/s41593-020-0658-y -o /tmp/bench --no-scihub
```

Downloaded a valid 4.4 MB PDF through Unpaywall in ~2.2s.

```bash
paper-search search "The extent and drivers of gender imbalance in neuroscience reference lists" -s google_scholar -n 2 --source-timeout 2
```

Returned a structured timeout error instead of hanging indefinitely.

Also tested `SciHubFetcher` with the default mirror: `sci-hub.se` failed DNS locally, then the dynamic mirror list found a working mirror and downloaded a valid PDF.
