### PR TITLE
Make CLI search defaults faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
   - **Layer 1 (Unified Tooling)**: High-level `search_papers` for multi-source concurrent search & deduplication, and `download_with_fallback` relying on publisher open access links with sequential fallbacks.
   - **Layer 2 (Platform Connectors)**: Modular connectors for specific academic platforms (arXiv, PubMed, bioRxiv, Semantic Scholar, etc.) equipped with intelligent DOI extraction via regex text analysis or API fields.
 - **Multi-Source Support**: Search and download papers from arXiv, PubMed, bioRxiv, medRxiv, Google Scholar, IACR ePrint Archive, Semantic Scholar, Crossref, OpenAlex, PubMed Central (PMC), CORE, Europe PMC, dblp, OpenAIRE, CiteSeerX, DOAJ, BASE, Zenodo, HAL, SSRN, Unpaywall (DOI lookup), and optional Sci-Hub workflows.
+- **Fast Search Defaults**: CLI search defaults to a curated fast set (OpenAlex, Crossref, arXiv, PubMed, Europe PMC). Slow or rate-limited broad sources remain available via explicit source selection or `--exhaustive`.
 - **Standardized Output**: Papers are returned in a consistent dictionary format via the `Paper` class.
 - **Free-First Design**: Open and public sources are prioritized before any optional commercial or restricted integrations.
 - **Optional API-Key Enhancement**: Sources like Semantic Scholar can work better with a user-provided API key, but are not intended to force paid usage.
@@ -229,6 +230,27 @@ Create a `.env` file in the repo root for optional API keys (see [Environment Va
 - "Download the PDF for arxiv paper 2106.12345"
 
 The skill uses a CLI (`paper-search`) that wraps the same library as the MCP server, outputting JSON for search/download and plain text for read.
+
+Useful CLI examples:
+
+```bash
+paper-search search "gender imbalance neuroscience references" -n 3
+paper-search search "gender imbalance neuroscience references" -s fastest -n 3
+paper-search search "gender imbalance neuroscience references" --exhaustive -s all -n 3
+paper-search download semantic DOI:10.1038/s41593-020-0658-y -o ./downloads
+```
+
+For broad topic search, the CLI defaults to `-s fast`, which keeps arXiv in
+the search set but avoids known slow/noisy topic-search paths such as
+anonymous Semantic Scholar retries, CORE, PMC, Google Scholar, and Unpaywall.
+If `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` is configured, Semantic Scholar
+is added back to the fast set because authenticated access avoids the anonymous
+rate-limit delay. Use `-s fastest` for only OpenAlex and Crossref, or
+`--exhaustive -s all` when coverage matters more than latency.
+
+Use `download-doi` for DOI retrieval. `unpaywall` is automatically added to
+generic `search` only when the query contains a DOI, because Unpaywall is a DOI
+lookup service rather than a broad topic search engine.
 
 ---
 

--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -160,8 +160,8 @@ class SemanticSearcher(PaperSource):
         """
         Make a request to the Semantic Scholar API with optional API key.
         """
-        max_retries = 3
         api_key = self.get_api_key()
+        max_retries = 3 if api_key else 1
         retry_delay = 5 if api_key is None else 2
         has_retried_without_key = False
 
@@ -187,6 +187,16 @@ class SemanticSearcher(PaperSource):
 
                 # 检查是否是429错误（限流）
                 if response.status_code == 429:
+                    if api_key is None:
+                        logger.warning(
+                            "Semantic Scholar anonymous access is rate-limited (429). "
+                            "Skipping retries; set SEMANTIC_SCHOLAR_API_KEY for higher limits."
+                        )
+                        return {
+                            "error": "rate_limited",
+                            "status_code": 429,
+                            "message": "Too many requests. Set SEMANTIC_SCHOLAR_API_KEY for higher limits.",
+                        }
                     if attempt < max_retries - 1:
                         retry_after = response.headers.get("Retry-After")
                         wait_time = (
@@ -225,6 +235,16 @@ class SemanticSearcher(PaperSource):
                     has_retried_without_key = True
                     continue
                 if e.response.status_code == 429:
+                    if api_key is None:
+                        logger.warning(
+                            "Semantic Scholar anonymous access is rate-limited (429). "
+                            "Skipping retries; set SEMANTIC_SCHOLAR_API_KEY for higher limits."
+                        )
+                        return {
+                            "error": "rate_limited",
+                            "status_code": 429,
+                            "message": "Too many requests. Set SEMANTIC_SCHOLAR_API_KEY for higher limits.",
+                        }
                     if attempt < max_retries - 1:
                         retry_after = e.response.headers.get("Retry-After")
                         wait_time = (

--- a/paper_search_mcp/cli.py
+++ b/paper_search_mcp/cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import re
 import sys
 from typing import Any, Dict, List
 
@@ -39,44 +40,58 @@ from .academic_platforms.ssrn import SSRNSearcher
 SEARCHERS: Dict[str, Any] = {}
 
 
-def _init_searchers() -> None:
-    """Lazily initialize searcher instances."""
-    if SEARCHERS:
-        return
+def _available_sources() -> list[str]:
+    sources = list(ALL_SOURCES)
+    if get_env("IEEE_API_KEY", ""):
+        sources.append("ieee")
+    if get_env("ACM_API_KEY", ""):
+        sources.append("acm")
+    return sources
 
-    SEARCHERS["arxiv"] = ArxivSearcher()
-    SEARCHERS["pubmed"] = PubMedSearcher()
-    SEARCHERS["biorxiv"] = BioRxivSearcher()
-    SEARCHERS["medrxiv"] = MedRxivSearcher()
-    SEARCHERS["google_scholar"] = GoogleScholarSearcher()
-    SEARCHERS["iacr"] = IACRSearcher()
-    SEARCHERS["semantic"] = SemanticSearcher()
-    SEARCHERS["crossref"] = CrossRefSearcher()
-    SEARCHERS["openalex"] = OpenAlexSearcher()
-    SEARCHERS["pmc"] = PMCSearcher()
-    SEARCHERS["core"] = CORESearcher()
-    SEARCHERS["europepmc"] = EuropePMCSearcher()
-    SEARCHERS["dblp"] = DBLPSearcher()
-    SEARCHERS["openaire"] = OpenAiresearcher()
-    SEARCHERS["citeseerx"] = CiteSeerXSearcher()
-    SEARCHERS["doaj"] = DOAJSearcher()
-    SEARCHERS["base"] = BASESearcher()
-    unpaywall_resolver = UnpaywallResolver()
-    SEARCHERS["unpaywall"] = UnpaywallSearcher(resolver=unpaywall_resolver)
-    SEARCHERS["zenodo"] = ZenodoSearcher()
-    SEARCHERS["hal"] = HALSearcher()
-    SEARCHERS["ssrn"] = SSRNSearcher()
 
-    # Optional paid connectors
-    ieee_key = get_env("IEEE_API_KEY", "")
-    if ieee_key:
+def _get_searcher(source: str) -> Any:
+    """Initialize only the searcher requested by the current command."""
+    if source in SEARCHERS:
+        return SEARCHERS[source]
+
+    factories = {
+        "arxiv": ArxivSearcher,
+        "pubmed": PubMedSearcher,
+        "biorxiv": BioRxivSearcher,
+        "medrxiv": MedRxivSearcher,
+        "google_scholar": GoogleScholarSearcher,
+        "iacr": IACRSearcher,
+        "semantic": SemanticSearcher,
+        "crossref": CrossRefSearcher,
+        "openalex": OpenAlexSearcher,
+        "pmc": PMCSearcher,
+        "core": CORESearcher,
+        "europepmc": EuropePMCSearcher,
+        "dblp": DBLPSearcher,
+        "openaire": OpenAiresearcher,
+        "citeseerx": CiteSeerXSearcher,
+        "doaj": DOAJSearcher,
+        "base": BASESearcher,
+        "zenodo": ZenodoSearcher,
+        "hal": HALSearcher,
+        "ssrn": SSRNSearcher,
+    }
+
+    if source == "unpaywall":
+        searcher = UnpaywallSearcher(resolver=UnpaywallResolver())
+    elif source == "ieee" and get_env("IEEE_API_KEY", ""):
         from .academic_platforms.ieee import IEEESearcher
-        SEARCHERS["ieee"] = IEEESearcher()
-
-    acm_key = get_env("ACM_API_KEY", "")
-    if acm_key:
+        searcher = IEEESearcher()
+    elif source == "acm" and get_env("ACM_API_KEY", ""):
         from .academic_platforms.acm import ACMSearcher
-        SEARCHERS["acm"] = ACMSearcher()
+        searcher = ACMSearcher()
+    elif source in factories:
+        searcher = factories[source]()
+    else:
+        raise KeyError(source)
+
+    SEARCHERS[source] = searcher
+    return searcher
 
 
 ALL_SOURCES = [
@@ -86,12 +101,45 @@ ALL_SOURCES = [
     "ssrn", "unpaywall",
 ]
 
+FASTEST_SOURCES = [
+    "openalex", "crossref",
+]
 
-def _parse_sources(sources: str) -> List[str]:
-    if not sources or sources.strip().lower() == "all":
-        return [s for s in ALL_SOURCES if s in SEARCHERS]
+FAST_SOURCES = [
+    "openalex", "crossref", "arxiv", "pubmed", "europepmc",
+]
+
+DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Z0-9]+\b", re.IGNORECASE)
+
+
+def _fast_sources() -> list[str]:
+    sources = list(FAST_SOURCES)
+    if get_env("SEMANTIC_SCHOLAR_API_KEY", ""):
+        sources.insert(2, "semantic")
+    return sources
+
+
+def _parse_sources(sources: str, exhaustive: bool = False) -> List[str]:
+    if not sources:
+        source_names = ALL_SOURCES if exhaustive else _fast_sources()
+        available = set(_available_sources())
+        return [s for s in source_names if s in available]
+
+    sources = sources.strip().lower()
+    if sources == "all":
+        source_names = ALL_SOURCES if exhaustive else _fast_sources()
+        available = set(_available_sources())
+        return [s for s in source_names if s in available]
+    if sources == "fast":
+        available = set(_available_sources())
+        return [s for s in _fast_sources() if s in available]
+    if sources == "fastest":
+        available = set(_available_sources())
+        return [s for s in FASTEST_SOURCES if s in available]
+
     normalized = [p.strip().lower() for p in sources.split(",") if p.strip()]
-    return [s for s in normalized if s in SEARCHERS]
+    available = set(_available_sources())
+    return [s for s in normalized if s in available]
 
 
 def _paper_unique_key(paper: Dict[str, Any]) -> str:
@@ -133,15 +181,16 @@ async def _async_search(searcher: Any, query: str, max_results: int, **kwargs) -
 # ---------------------------------------------------------------------------
 
 async def cmd_search(args: argparse.Namespace) -> int:
-    _init_searchers()
-    selected = _parse_sources(args.sources)
+    selected = _parse_sources(args.sources, args.exhaustive)
+    if DOI_RE.search(args.query) and "unpaywall" not in selected and "unpaywall" in _available_sources():
+        selected.append("unpaywall")
     if not selected:
-        print(json.dumps({"error": "No valid sources selected", "available": sorted(SEARCHERS.keys())}))
+        print(json.dumps({"error": "No valid sources selected", "available": sorted(_available_sources())}))
         return 1
 
     tasks = {}
     for src in selected:
-        searcher = SEARCHERS[src]
+        searcher = _get_searcher(src)
         extra = {}
         if src == "semantic" and args.year:
             extra["year"] = args.year
@@ -170,6 +219,8 @@ async def cmd_search(args: argparse.Namespace) -> int:
     output = {
         "query": args.query,
         "sources_used": names,
+        "search_mode": "exhaustive" if args.exhaustive else "fast",
+        "source_preset": args.sources,
         "source_results": source_counts,
         "errors": errors,
         "total": len(deduped),
@@ -180,14 +231,13 @@ async def cmd_search(args: argparse.Namespace) -> int:
 
 
 async def cmd_download(args: argparse.Namespace) -> int:
-    _init_searchers()
     source = args.source.strip().lower()
 
-    if source not in SEARCHERS:
-        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(SEARCHERS.keys())}))
+    if source not in _available_sources():
+        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(_available_sources())}))
         return 1
 
-    searcher = SEARCHERS[source]
+    searcher = _get_searcher(source)
     try:
         result = await asyncio.to_thread(searcher.download_pdf, args.paper_id, args.save_path)
         print(json.dumps({"status": "ok", "path": result}))
@@ -198,14 +248,13 @@ async def cmd_download(args: argparse.Namespace) -> int:
 
 
 async def cmd_read(args: argparse.Namespace) -> int:
-    _init_searchers()
     source = args.source.strip().lower()
 
-    if source not in SEARCHERS:
-        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(SEARCHERS.keys())}))
+    if source not in _available_sources():
+        print(json.dumps({"error": f"Unknown source: {source}", "available": sorted(_available_sources())}))
         return 1
 
-    searcher = SEARCHERS[source]
+    searcher = _get_searcher(source)
     try:
         text = await asyncio.to_thread(searcher.read_paper, args.paper_id, args.save_path)
         print(text)
@@ -216,8 +265,7 @@ async def cmd_read(args: argparse.Namespace) -> int:
 
 
 async def cmd_sources(args: argparse.Namespace) -> int:
-    _init_searchers()
-    print(json.dumps({"sources": sorted(SEARCHERS.keys())}, indent=2))
+    print(json.dumps({"sources": sorted(_available_sources())}, indent=2))
     return 0
 
 
@@ -236,10 +284,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_search = sub.add_parser("search", help="Search for papers across academic platforms")
     p_search.add_argument("query", help="Search query")
     p_search.add_argument("-n", "--max-results", type=int, default=5, help="Max results per source (default: 5)")
-    p_search.add_argument("-s", "--sources", default="all",
-                          help="Comma-separated sources or 'all' (default: all)")
+    p_search.add_argument("-s", "--sources", default="fast",
+                          help="Comma-separated sources, 'fastest', 'fast', or 'all' (default: fast)")
     p_search.add_argument("-y", "--year", default=None,
                           help="Year filter for Semantic Scholar (e.g. '2020', '2018-2022')")
+    p_search.add_argument("--exhaustive", action="store_true",
+                          help="Use the old broad source set when sources are omitted or set to 'all'")
 
     # download
     p_dl = sub.add_parser("download", help="Download a paper PDF")

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -3,6 +3,7 @@ import asyncio
 from unittest.mock import patch, AsyncMock
 
 from paper_search_mcp import server
+from paper_search_mcp import cli
 
 
 class TestDownloadWithFallback(unittest.TestCase):
@@ -52,6 +53,28 @@ class TestDownloadWithFallback(unittest.TestCase):
             )
             self.assertIn("OA fallback chain", result)
 
+    def test_parse_sources_defaults_to_fast_set(self):
+        cli.SEARCHERS.clear()
+        selected = cli._parse_sources("fast")
+        self.assertEqual(selected, [s for s in cli._fast_sources() if s in cli._available_sources()])
+        self.assertEqual(cli.SEARCHERS, {})
+
+        fastest = cli._parse_sources("fastest")
+        self.assertEqual(fastest, [s for s in cli.FASTEST_SOURCES if s in cli._available_sources()])
+        self.assertLess(len(fastest), len(selected))
+
+        selected_from_all = cli._parse_sources("all")
+        self.assertEqual(selected_from_all, selected)
+
+        exhaustive = cli._parse_sources("all", exhaustive=True)
+        self.assertIn("google_scholar", exhaustive)
+        self.assertGreater(len(exhaustive), len(selected))
+
+    def test_fast_sources_include_semantic_when_key_is_configured(self):
+        with patch.dict("os.environ", {"PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY": "test-key"}):
+            selected = cli._parse_sources("fast")
+
+        self.assertIn("semantic", selected)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -64,6 +64,18 @@ class TestSemanticSearcher(unittest.TestCase):
         self.assertIsNotNone(paper)
         self.assertIsNone(paper.published_date)
 
+    def test_anonymous_rate_limit_fails_fast(self):
+        response = Mock()
+        response.status_code = 429
+        response.headers = {}
+
+        with patch.object(self.searcher, "get_api_key", return_value=None), \
+             patch.object(self.searcher.session, "get", return_value=response) as get:
+            result = self.searcher.request_api("paper/search", {"query": "test"})
+
+        self.assertEqual(result["error"], "rate_limited")
+        self.assertEqual(get.call_count, 1)
+
     @unittest.skipUnless(check_semantic_accessible(), "Semantic Scholar not accessible")
     def test_search_basic(self):
         """Test basic search functionality"""


### PR DESCRIPTION
## Summary

This PR makes the CLI `paper-search search` path faster by default while preserving broad coverage as an explicit opt-in.

Changes:
- Adds `fast` and `fastest` source presets.
- Makes `fast` the default source preset: OpenAlex, Crossref, arXiv, PubMed, Europe PMC.
- Adds Semantic Scholar to `fast` only when `PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY` / `SEMANTIC_SCHOLAR_API_KEY` is configured.
- Keeps exhaustive broad search available with `--exhaustive -s all`.
- Lazy-initializes only selected searchers, avoiding setup/warning overhead for unused sources.
- Auto-adds Unpaywall to generic search only when the query contains a DOI.
- Makes anonymous Semantic Scholar 429s fail fast instead of sleeping/retrying.

## Why

Some sources are excellent for retrieval or exhaustive discovery, but are poor defaults for a broad topic query:

- Unpaywall is DOI-centric and returned no topic-search results in testing, while adding latency.
- Anonymous Semantic Scholar can spend time retrying 429s; if a key is configured, it is valuable and included in `fast`.
- CORE/PMC/Google Scholar can be useful but are slower/noisier as default topic-search sources.
- arXiv remains in the default because it can contribute unique useful papers.

This keeps the CLI responsive for default agent workflows without removing any source.

## Verification

```bash
uv run pytest tests/test_fallback.py tests/test_semantic.py -q
# 10 passed, 6 skipped
```

Local benchmark on a broad SDM query showed the old path could spend ~16s when anonymous Semantic Scholar hit 429s, while the curated fast set avoids that retry delay. Source overlap checks also showed arXiv contributed unique results, so it stays in the default fast set.
