### PR TITLE
fix: handle None fieldsOfStudy in Semantic Scholar parser

### DIFF
--- a/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper_search_mcp/academic_platforms/semantic.py
@@ -123,6 +123,8 @@ class SemanticSearcher(PaperSource):
             categories = item.get("fieldsOfStudy", [])
             if not categories:
                 categories = []
+            elif not isinstance(categories, list):
+                categories = [categories] if categories else []
 
             return Paper(
                 paper_id=item["paperId"],


### PR DESCRIPTION
Fixed a bug where `fieldsOfStudy` could be `None` instead of a list, causing a crash during paper parsing. Added an `isinstance` check to normalize non-list values.