### PR TITLE
fix: coerce paper_id/pdf_url to str in repository fallback (closes #57)

### DIFF
--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -226,11 +226,12 @@ async def _try_repository_fallback(doi: str, title: str, save_path: str) -> tupl
                 continue
 
             for paper in papers:
-                pdf_url = (getattr(paper, "pdf_url", "") or "").strip()
+                pdf_url = str(getattr(paper, "pdf_url", "") or "").strip()
                 if not pdf_url:
                     continue
 
-                paper_id = (getattr(paper, "paper_id", "") or query).strip()
+                raw_paper_id = getattr(paper, "paper_id", "")
+                paper_id = str(raw_paper_id or query).strip()
                 downloaded = await _download_from_url(pdf_url, save_path, f"{repo_name}_{paper_id}")
                 if downloaded:
                     return downloaded, ""

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -53,5 +53,33 @@ class TestDownloadWithFallback(unittest.TestCase):
             self.assertIn("OA fallback chain", result)
 
 
+class TestRepositoryFallbackNumericPaperId(unittest.TestCase):
+    """Regression test for issue #57: _try_repository_fallback crashed when a
+    repository connector returned a Paper whose paper_id was a non-string
+    (int) value, because the code called .strip() on it directly."""
+
+    def test_numeric_paper_id_does_not_crash(self):
+        class FakePaper:
+            pdf_url = "https://example.org/oa.pdf"
+            paper_id = 12345  # int, not str — caused 'int' object has no attribute 'strip'
+
+        fake_searcher = type(
+            "S", (), {"search": staticmethod(lambda q, max_results=3: [FakePaper()])}
+        )
+
+        # Patch one of the repository searchers to return our FakePaper.
+        with patch.object(server, "openaire_searcher", fake_searcher), \
+             patch("paper_search_mcp.server._download_from_url", new=AsyncMock(return_value="/tmp/ok.pdf")):
+            result, err = asyncio.run(
+                server._try_repository_fallback(
+                    doi="10.1000/test",
+                    title="some title",
+                    save_path="/tmp",
+                )
+            )
+            self.assertEqual(result, "/tmp/ok.pdf")
+            self.assertEqual(err, "")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'int' object has no attribute 'strip'` raised inside `_try_repository_fallback` (`paper_search_mcp/server.py:233`), which crashed `download_with_fallback` whenever a repository connector (openaire / core / europepmc / pmc) returned a `Paper` with a non-string `paper_id` (most commonly an `int`).

Closes #57.

## What changes

`paper_search_mcp/server.py`, in `_try_repository_fallback`:

```python
# before
pdf_url = (getattr(paper, "pdf_url", "") or "").strip()
paper_id = (getattr(paper, "paper_id", "") or query).strip()

# after
pdf_url = str(getattr(paper, "pdf_url", "") or "").strip()
raw_paper_id = getattr(paper, "paper_id", "")
paper_id = str(raw_paper_id or query).strip()
```

Wrapping both values in `str(...)` makes the fallback chain robust to any connector that decides to emit a numeric (or otherwise non-string) identifier — it no longer crashes before Unpaywall/Sci-Hub are even attempted.

## Why this matters

In the wild this is not a rare edge case. I hit the crash on **every single** `download_with_fallback` call during a batch acquisition of ~20 closed-access references this week — `source` didn't matter (`crossref`, `openalex`, `semantic` all crashed identically), `doi` didn't matter, `use_scihub` didn't matter. The crash happens in the repository step before any of those options gets a turn. So in practice the tool was effectively unusable for closed-access papers until this is fixed.

## Test plan

- [x] Added regression test `TestRepositoryFallbackNumericPaperId.test_numeric_paper_id_does_not_crash` in `tests/test_fallback.py` — feeds a `Paper(paper_id=12345)` through `_try_repository_fallback` and asserts it completes without raising.
- [x] All 4 tests in `tests/test_fallback.py` pass (`uv run python -m unittest tests.test_fallback -v`).
- [x] Verified the same fix as the one suggested in #57 by the original reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)