### PR TITLE
Support OpenAlex search filters

### DIFF
--- a/paper_search_mcp/academic_platforms/openalex.py
+++ b/paper_search_mcp/academic_platforms/openalex.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 from datetime import datetime
 import requests
 import logging
@@ -40,13 +40,14 @@ class OpenAlexSearcher(PaperSource):
             logger.warning(f"Error reconstructing OpenAlex abstract: {e}")
             return ""
 
-    def search(self, query: str, max_results: int = 10) -> List[Paper]:
+    def search(self, query: str, max_results: int = 10, **kwargs: Any) -> List[Paper]:
         """
         Search OpenAlex works. Uses the 'search' filter.
 
         Args:
             query: Search query string
             max_results: Maximum results to return (natively max 200 per page)
+            **kwargs: Additional OpenAlex parameters like `filter`.
 
         Returns:
             List[Paper]: List of found papers with metadata.
@@ -58,6 +59,8 @@ class OpenAlexSearcher(PaperSource):
                 "search": query,
                 "per_page": min(max_results, 200),
             }
+            if "filter" in kwargs:
+                params["filter"] = kwargs["filter"]
 
             response = self.session.get(self.BASE_URL, params=params, timeout=30)
             

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -864,16 +864,28 @@ async def read_crossref_paper(paper_id: str, save_path: str = "./downloads") -> 
 
 
 @mcp.tool()
-async def search_openalex(query: str, max_results: int = 10) -> List[Dict]:
+async def search_openalex(
+    query: str,
+    max_results: int = 10,
+    filter: Optional[str] = None,
+) -> List[Dict]:
     """Search academic papers from OpenAlex.
 
     Args:
         query: Search query string (e.g., 'machine learning').
         max_results: Maximum number of papers to return (default: 10).
+        filter: OpenAlex filter string.
+            Examples:
+            - 'is_oa:true,from_publication_date:2024-01-01'
+            - 'has_pdf_url:true,publication_year:2024'
+            - 'primary_location.source.id:S137773608' for Nature
+            See https://docs.openalex.org/api-entities/works/filter-works
+            for the full list of supported work filters.
     Returns:
         List of paper metadata in dictionary format.
     """
-    papers = await async_search(openalex_searcher, query, max_results)
+    extra = {k: v for k, v in {"filter": filter}.items() if v is not None}
+    papers = await async_search(openalex_searcher, query, max_results, **extra)
     return papers if papers else []
 
 

--- a/tests/test_openalex.py
+++ b/tests/test_openalex.py
@@ -1,0 +1,52 @@
+import unittest
+
+import requests
+
+from paper_search_mcp.academic_platforms.openalex import OpenAlexSearcher
+
+
+def check_api_accessible() -> bool:
+    """Check whether the OpenAlex API is reachable."""
+    try:
+        response = requests.get("https://api.openalex.org/works?per_page=1", timeout=5)
+        return response.status_code == 200
+    except requests.RequestException:
+        return False
+
+
+class TestOpenAlexSearcher(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.api_accessible = check_api_accessible()
+        if not cls.api_accessible:
+            print("\nWarning: OpenAlex API is not accessible, some tests will be skipped")
+
+    def setUp(self):
+        self.searcher = OpenAlexSearcher()
+
+    def test_search(self):
+        if not self.api_accessible:
+            self.skipTest("OpenAlex API is not accessible")
+
+        papers = self.searcher.search("machine learning", max_results=5)
+        self.assertGreater(len(papers), 0)
+        self.assertTrue(papers[0].title)
+
+    def test_search_with_filter(self):
+        if not self.api_accessible:
+            self.skipTest("OpenAlex API is not accessible")
+
+        papers = self.searcher.search(
+            "artificial intelligence",
+            max_results=3,
+            filter="is_oa:true,has_pdf_url:true",
+        )
+        self.assertGreaterEqual(len(papers), 0)
+
+    def test_user_agent_header(self):
+        self.assertIn("paper-search-mcp", self.searcher.session.headers.get("User-Agent", ""))
+        self.assertIn("mailto:", self.searcher.session.headers.get("User-Agent", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add OpenAlex filter passthrough support to `search_openalex`, similar to `search_crossref`.