### PR TITLE
Install the Claude Code skill without cloning repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # paper-search-mcp unified environment configuration
-# Copy this file to .env and fill in the values you need.
+# Copy this file to ~/.config/paper-search-mcp/.env and fill in the values you need.
 # Preferred format: PAPER_SEARCH_MCP_<NAME>
 
 # Core optional keys/tokens

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This matrix reflects **verified live-integration results** from functional and e
 
 ## Credential & API Key Requirements
 
-All keys are **optional** unless noted. Configure them in `.env` (preferred) or as shell exports.
+All keys are **optional** unless noted. Configure them in `~/.config/paper-search-mcp/.env` (preferred) or as shell exports.
 
 | Environment Variable | Provider | Required? | How to obtain |
 |---|---|---|---|
@@ -144,7 +144,7 @@ Some search failures are caused by external provider instability, not by bugs in
 | BASE | Search returns 0 results | OAI-PMH endpoint requires institutional IP registration | Register at [base-search.net](https://www.base-search.net/about/en/) for API access; connector returns empty gracefully otherwise |
 | SSRN | HTTP 403 | Bot-detection (Cloudflare) | No workaround; connector tries two endpoints and returns a clear message on failure |
 | PMC / Europe PMC | PDF download ProxyError | Local proxy blocking direct HTTPS PDF download | Disable proxy or use `download_with_fallback` instead |
-| Unpaywall | Skipped entirely | `UNPAYWALL_EMAIL` env var not set | Set `PAPER_SEARCH_MCP_UNPAYWALL_EMAIL` in `.env` |
+| Unpaywall | Skipped entirely | `UNPAYWALL_EMAIL` env var not set | Set `PAPER_SEARCH_MCP_UNPAYWALL_EMAIL` in `~/.config/paper-search-mcp/.env` |
 
 ## Optional Paid Platform Connectors (Phase 3)
 
@@ -201,26 +201,23 @@ Install as a Claude Code skill instead of an MCP server. This gives Claude autom
 
 **Prerequisites**: [uv](https://docs.astral.sh/uv/getting-started/installation/) and [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview).
 
-**Step 1 — Clone the repo:**
+**Step 1 — Install the CLI:**
 
 ```bash
-git clone https://github.com/openags/paper-search-mcp.git ~/paper-search-mcp
+uv tool install paper-search-mcp
 ```
 
 **Step 2 — Install the skill:**
 
 ```bash
 mkdir -p ~/.claude/skills/paper-search
-cp ~/paper-search-mcp/claude-code/SKILL.md ~/.claude/skills/paper-search/SKILL.md
+curl -fsSL https://raw.githubusercontent.com/openags/paper-search-mcp/main/claude-code/SKILL.md \
+  -o ~/.claude/skills/paper-search/SKILL.md
 ```
 
-**Step 3 — Update the repo path in the skill:**
+**Step 3 (optional) — Configure API keys:**
 
-Edit `~/.claude/skills/paper-search/SKILL.md` and replace every `<REPO_PATH>` with the absolute path to your clone (e.g. `/Users/yourname/paper-search-mcp`).
-
-**Step 4 (optional) — Configure API keys:**
-
-Create a `.env` file in the repo root for optional API keys (see [Environment Variables](#environment-variables-env-file)).
+Create `~/.config/paper-search-mcp/.env` for optional API keys (see [Environment Variables](#environment-variables-env-file)).
 
 **That's it.** Next time you start Claude Code, just ask it to find papers — the skill activates automatically. For example:
 
@@ -467,11 +464,13 @@ uv pip install -e ".[dev]"
 
 ### Environment Variables (`.env` file)
 
-Instead of putting keys directly in the JSON config you can store them in a `.env` file in the project root (auto-loaded on startup):
+Instead of putting keys directly in the JSON config you can store them in the user config file (auto-loaded on startup):
 
 ```bash
-cp .env.example .env   # if running from source
-# or create ~/.paper-search-mcp.env for global use
+mkdir -p ~/.config/paper-search-mcp
+curl -fsSL https://raw.githubusercontent.com/openags/paper-search-mcp/main/.env.example \
+  -o ~/.config/paper-search-mcp/.env
+$EDITOR ~/.config/paper-search-mcp/.env
 ```
 
 ```dotenv

--- a/claude-code/SKILL.md
+++ b/claude-code/SKILL.md
@@ -11,14 +11,14 @@ Search, download, and read academic papers via the `paper-search` CLI.
 
 All commands run via:
 ```bash
-uv run --directory <REPO_PATH> paper-search <command> [args]
+paper-search <command> [args]
 ```
 
-Replace `<REPO_PATH>` with the absolute path to your clone of this repository.
+If `paper-search` is not available, install it with `uv tool install paper-search-mcp`. Optional API keys can be configured in `~/.config/paper-search-mcp/.env`.
 
 ### Search
 ```bash
-uv run --directory <REPO_PATH> paper-search search "<query>" -n <max_per_source> -s <sources> -y <year>
+paper-search search "<query>" -n <max_per_source> -s <sources> -y <year>
 ```
 - `-n`: results per source (default: 5)
 - `-s`: comma-separated sources or "all" (default: all)
@@ -28,17 +28,17 @@ For speed, prefer targeted sources (`-s arxiv,semantic,crossref`) over "all" unl
 
 ### Download PDF
 ```bash
-uv run --directory <REPO_PATH> paper-search download <source> <paper_id> [-o ./downloads]
+paper-search download <source> <paper_id> [-o ./downloads]
 ```
 
 ### Read (extract text)
 ```bash
-uv run --directory <REPO_PATH> paper-search read <source> <paper_id> [-o ./downloads]
+paper-search read <source> <paper_id> [-o ./downloads]
 ```
 
 ### List sources
 ```bash
-uv run --directory <REPO_PATH> paper-search sources
+paper-search sources
 ```
 
 ## Output

--- a/paper_search_mcp/config.py
+++ b/paper_search_mcp/config.py
@@ -16,12 +16,8 @@ def _candidate_env_files() -> list[Path]:
     if explicit_path:
         return [Path(explicit_path).expanduser()]
 
-    cwd_env = Path.cwd() / ".env"
-    project_env = Path(__file__).resolve().parent.parent / ".env"
-
-    if cwd_env == project_env:
-        return [cwd_env]
-    return [cwd_env, project_env]
+    user_config_env = Path.home() / ".config" / "paper-search-mcp" / ".env"
+    return [user_config_env]
 
 
 def _strip_quotes(value: str) -> str:


### PR DESCRIPTION
## Summary

Simplifies the Claude Code skill so users no longer need to clone the repo or
edit `<REPO_PATH>` placeholders, and moves the env-file lookup to a stable global
location so the globally-installed `paper-search` CLI can find API keys.

- **`claude-code/SKILL.md`**: CLI commands now call `paper-search` directly
  instead of `uv run --directory <REPO_PATH> paper-search`. Added an install hint
  (`uv tool install paper-search-mcp`) and a pointer to
  `~/.config/paper-search-mcp/.env` for optional keys. Removed the `<REPO_PATH>`
  placeholder.
- **`README.md`** (Skill Installation): replaces "clone the repo" with
  `uv tool install paper-search-mcp`, fetches `SKILL.md` via a single `curl`, and
  drops the `<REPO_PATH>` edit step. Credential/env docs now point to
  `~/.config/paper-search-mcp/.env`.
- **`paper_search_mcp/config.py`**: `_candidate_env_files()` now resolves a single
  user-config path, `~/.config/paper-search-mcp/.env` (still overridable via
  `PAPER_SEARCH_MCP_ENV_FILE`). The previous `./.env` and project-root `.env`
  lookups are removed — a globally-installed CLI has no meaningful "project root".
- **`.env.example`**: header comment updated to the new path.

## Behavior change to note

`.env` in the current working directory and in the repo root is **no longer
auto-loaded**. Keys must live in `~/.config/paper-search-mcp/.env` (or a path set
via `PAPER_SEARCH_MCP_ENV_FILE`). This is intentional: the skill invokes
`paper-search` as a globally installed tool, so a repo-relative `.env` doesn't
apply.

## Test plan

- [x] `uv run --with pytest python -m pytest tests/test_config_env.py -q` — 4 passed
- [x] The published PyPI `0.1.4` already ships the `paper-search` console script,
  so `uv tool install paper-search-mcp` provides the CLI immediately — no new
  release required
- [x] Maintainer: `uv tool install paper-search-mcp && paper-search sources` from a
  fresh shell returns the source list
- [x] Maintainer: keys placed in `~/.config/paper-search-mcp/.env` are picked up by
  the globally-installed CLI
