### PR TITLE
fix: replace bare except: with except Exception: in iacr.py

### DIFF
--- a/paper_search_mcp/academic_platforms/iacr.py
+++ b/paper_search_mcp/academic_platforms/iacr.py
@@ -367,7 +367,7 @@ class IACRSearcher(PaperSource):
             try:
                 keyword_elements = soup.select("a.badge.bg-secondary.keyword")
                 keywords = [elem.get_text(strip=True) for elem in keyword_elements]
-            except:
+            except Exception:
                 keywords = []
 
             # Find history entries


### PR DESCRIPTION
Fixed a bug I found while browsing. Replaced bare `except:` with `except Exception:` in `iacr.py` line 370. Bare except clauses catch all exceptions including `SystemExit` and `KeyboardInterrupt`, which is bad practice and can mask serious errors.