### PR TITLE
feat: add MCP tool annotations to all tools

### DIFF
--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -239,7 +239,7 @@ async def _try_repository_fallback(doi: str, title: str, save_path: str) -> tupl
     return None, "; ".join(repository_errors)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_papers(
     query: str,
     max_results_per_source: int = 5,
@@ -355,7 +355,7 @@ async def search_papers(
 
 
 # Tool definitions
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_arxiv(query: str, max_results: int = 10, sort_by: str = 'relevance', sort_order: str = 'descending') -> List[Dict]:
     """Search academic papers from arXiv.
 
@@ -371,7 +371,7 @@ async def search_arxiv(query: str, max_results: int = 10, sort_by: str = 'releva
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_pubmed(query: str, max_results: int = 10, sort: str = 'relevance') -> List[Dict]:
     """Search academic papers from PubMed.
 
@@ -386,7 +386,7 @@ async def search_pubmed(query: str, max_results: int = 10, sort: str = 'relevanc
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_biorxiv(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from bioRxiv.
 
@@ -404,7 +404,7 @@ async def search_biorxiv(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_medrxiv(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from medRxiv.
 
@@ -422,7 +422,7 @@ async def search_medrxiv(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_google_scholar(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from Google Scholar.
 
@@ -436,7 +436,7 @@ async def search_google_scholar(query: str, max_results: int = 10) -> List[Dict]
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_iacr(
     query: str, max_results: int = 10, fetch_details: bool = True
 ) -> List[Dict]:
@@ -453,7 +453,7 @@ async def search_iacr(
     return [paper.to_dict() for paper in papers] if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_arxiv(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF of an arXiv paper.
 
@@ -466,7 +466,7 @@ async def download_arxiv(paper_id: str, save_path: str = "./downloads") -> str:
     return await asyncio.to_thread(arxiv_searcher.download_pdf, paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_pubmed(paper_id: str, save_path: str = "./downloads") -> str:
     """Attempt to download PDF of a PubMed paper.
 
@@ -482,7 +482,7 @@ async def download_pubmed(paper_id: str, save_path: str = "./downloads") -> str:
         return str(e)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_biorxiv(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF of a bioRxiv paper.
 
@@ -495,7 +495,7 @@ async def download_biorxiv(paper_id: str, save_path: str = "./downloads") -> str
     return biorxiv_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_medrxiv(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF of a medRxiv paper.
 
@@ -508,7 +508,7 @@ async def download_medrxiv(paper_id: str, save_path: str = "./downloads") -> str
     return medrxiv_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_iacr(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF of an IACR ePrint paper.
 
@@ -521,7 +521,7 @@ async def download_iacr(paper_id: str, save_path: str = "./downloads") -> str:
     return iacr_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_arxiv_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from an arXiv paper PDF.
 
@@ -538,7 +538,7 @@ async def read_arxiv_paper(paper_id: str, save_path: str = "./downloads") -> str
         return ""
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_pubmed_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a PubMed paper.
 
@@ -551,7 +551,7 @@ async def read_pubmed_paper(paper_id: str, save_path: str = "./downloads") -> st
     return pubmed_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_biorxiv_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a bioRxiv paper PDF.
 
@@ -568,7 +568,7 @@ async def read_biorxiv_paper(paper_id: str, save_path: str = "./downloads") -> s
         return ""
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_medrxiv_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a medRxiv paper PDF.
 
@@ -585,7 +585,7 @@ async def read_medrxiv_paper(paper_id: str, save_path: str = "./downloads") -> s
         return ""
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_iacr_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from an IACR ePrint paper PDF.
 
@@ -602,7 +602,7 @@ async def read_iacr_paper(paper_id: str, save_path: str = "./downloads") -> str:
         return ""
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_semantic(query: str, year: Optional[str] = None, max_results: int = 10) -> List[Dict]:
     """Search academic papers from Semantic Scholar.
 
@@ -620,7 +620,7 @@ async def search_semantic(query: str, year: Optional[str] = None, max_results: i
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_semantic(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF of a Semantic Scholar paper.    
 
@@ -641,7 +641,7 @@ async def download_semantic(paper_id: str, save_path: str = "./downloads") -> st
     return semantic_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_semantic_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a Semantic Scholar paper. 
 
@@ -666,7 +666,7 @@ async def read_semantic_paper(paper_id: str, save_path: str = "./downloads") -> 
         return ""
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_crossref(
     query: str,
     max_results: int = 10,
@@ -695,7 +695,7 @@ async def search_crossref(
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def get_crossref_paper_by_doi(doi: str) -> Dict:
     """Get a specific paper from CrossRef by its DOI.
 
@@ -711,7 +711,7 @@ async def get_crossref_paper_by_doi(doi: str) -> Dict:
     return paper.to_dict() if paper else {}
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_crossref(paper_id: str, save_path: str = "./downloads") -> str:
     """Attempt to download PDF of a CrossRef paper.
 
@@ -731,7 +731,7 @@ async def download_crossref(paper_id: str, save_path: str = "./downloads") -> st
         return str(e)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_scihub(
     identifier: str,
     save_path: str = "./downloads",
@@ -753,7 +753,7 @@ async def download_scihub(
     return "Sci-Hub download failed. Try DOI first, then title, or change mirror URL."
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_with_fallback(
     source: str,
     paper_id: str,
@@ -846,7 +846,7 @@ async def download_with_fallback(
     return "Download failed after OA fallback chain and Sci-Hub fallback. Details: " + " | ".join(attempt_errors)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_crossref_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Attempt to read and extract text content from a CrossRef paper.
 
@@ -863,7 +863,7 @@ async def read_crossref_paper(paper_id: str, save_path: str = "./downloads") -> 
     return crossref_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_openalex(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from OpenAlex.
 
@@ -877,7 +877,7 @@ async def search_openalex(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_pmc(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from PubMed Central (PMC).
 
@@ -891,7 +891,7 @@ async def search_pmc(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_core(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from CORE.
 
@@ -905,7 +905,7 @@ async def search_core(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_europepmc(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from Europe PMC.
 
@@ -919,7 +919,7 @@ async def search_europepmc(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_dblp(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from dblp computer science bibliography.
 
@@ -933,7 +933,7 @@ async def search_dblp(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_openaire(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from OpenAIRE European Open Access infrastructure.
 
@@ -947,7 +947,7 @@ async def search_openaire(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_citeseerx(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from CiteSeerX digital library.
 
@@ -961,7 +961,7 @@ async def search_citeseerx(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_doaj(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from DOAJ (Directory of Open Access Journals).
 
@@ -975,7 +975,7 @@ async def search_doaj(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_base(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from BASE (Bielefeld Academic Search Engine).
 
@@ -989,7 +989,7 @@ async def search_base(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_zenodo(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from Zenodo open repository.
 
@@ -1003,7 +1003,7 @@ async def search_zenodo(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_hal(query: str, max_results: int = 10) -> List[Dict]:
     """Search academic papers from HAL open archive.
 
@@ -1017,7 +1017,7 @@ async def search_hal(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_ssrn(query: str, max_results: int = 10) -> List[Dict]:
     """Search metadata records from SSRN.
 
@@ -1033,7 +1033,7 @@ async def search_ssrn(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def search_unpaywall(query: str, max_results: int = 10) -> List[Dict]:
     """Lookup a DOI via Unpaywall and return OA metadata.
 
@@ -1050,7 +1050,7 @@ async def search_unpaywall(query: str, max_results: int = 10) -> List[Dict]:
     return papers if papers else []
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_dblp_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Attempt to read and extract text content from a dblp paper.
 
@@ -1066,7 +1066,7 @@ async def read_dblp_paper(paper_id: str, save_path: str = "./downloads") -> str:
     return dblp_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_dblp(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from dblp.
 
@@ -1082,7 +1082,7 @@ async def download_dblp(paper_id: str, save_path: str = "./downloads") -> str:
     return dblp_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_openaire_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Attempt to read and extract text content from an OpenAIRE paper.
 
@@ -1095,7 +1095,7 @@ async def read_openaire_paper(paper_id: str, save_path: str = "./downloads") -> 
     return openaire_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_openaire(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from OpenAIRE.
 
@@ -1108,7 +1108,7 @@ async def download_openaire(paper_id: str, save_path: str = "./downloads") -> st
     return openaire_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_citeseerx_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a CiteSeerX paper.
 
@@ -1121,7 +1121,7 @@ async def read_citeseerx_paper(paper_id: str, save_path: str = "./downloads") ->
     return citeseerx_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_citeseerx(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from CiteSeerX.
 
@@ -1134,7 +1134,7 @@ async def download_citeseerx(paper_id: str, save_path: str = "./downloads") -> s
     return citeseerx_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_doaj_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a DOAJ paper.
 
@@ -1147,7 +1147,7 @@ async def read_doaj_paper(paper_id: str, save_path: str = "./downloads") -> str:
     return doaj_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_doaj(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from DOAJ.
 
@@ -1160,7 +1160,7 @@ async def download_doaj(paper_id: str, save_path: str = "./downloads") -> str:
     return doaj_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_base_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a BASE paper.
 
@@ -1173,7 +1173,7 @@ async def read_base_paper(paper_id: str, save_path: str = "./downloads") -> str:
     return base_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_base(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from BASE.
 
@@ -1186,7 +1186,7 @@ async def download_base(paper_id: str, save_path: str = "./downloads") -> str:
     return base_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_zenodo_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a Zenodo paper.
 
@@ -1199,7 +1199,7 @@ async def read_zenodo_paper(paper_id: str, save_path: str = "./downloads") -> st
     return zenodo_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_zenodo(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from Zenodo.
 
@@ -1212,7 +1212,7 @@ async def download_zenodo(paper_id: str, save_path: str = "./downloads") -> str:
     return zenodo_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_hal_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read and extract text content from a HAL paper.
 
@@ -1225,7 +1225,7 @@ async def read_hal_paper(paper_id: str, save_path: str = "./downloads") -> str:
     return hal_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_hal(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from HAL.
 
@@ -1238,7 +1238,7 @@ async def download_hal(paper_id: str, save_path: str = "./downloads") -> str:
     return hal_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_ssrn_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Read paper content from SSRN.
 
@@ -1253,7 +1253,7 @@ async def read_ssrn_paper(paper_id: str, save_path: str = "./downloads") -> str:
     return ssrn_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_ssrn(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from SSRN.
 
@@ -1268,7 +1268,7 @@ async def download_ssrn(paper_id: str, save_path: str = "./downloads") -> str:
     return ssrn_searcher.download_pdf(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
 async def read_openalex_paper(paper_id: str, save_path: str = "./downloads") -> str:
     """Attempt to read and extract text content from an OpenAlex paper.
 
@@ -1281,7 +1281,7 @@ async def read_openalex_paper(paper_id: str, save_path: str = "./downloads") -> 
     return openalex_searcher.read_paper(paper_id, save_path)
 
 
-@mcp.tool()
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True})
 async def download_openalex(paper_id: str, save_path: str = "./downloads") -> str:
     """Download PDF for a paper from OpenAlex.
 
@@ -1298,7 +1298,7 @@ async def download_openalex(paper_id: str, save_path: str = "./downloads") -> st
 # Optional IEEE Xplore tools — registered only when API key is set
 # ---------------------------------------------------------------------------
 if ieee_searcher is not None:
-    @mcp.tool()
+    @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
     async def search_ieee(query: str, max_results: int = 10) -> List[Dict]:
         """Search IEEE Xplore for papers.  Requires PAPER_SEARCH_MCP_IEEE_API_KEY (or IEEE_API_KEY).
 
@@ -1310,7 +1310,7 @@ if ieee_searcher is not None:
         """
         return await async_search(ieee_searcher, query, max_results)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
     async def download_ieee(paper_id: str, save_path: str = "./downloads") -> str:
         """Download a PDF from IEEE Xplore.  Requires PAPER_SEARCH_MCP_IEEE_API_KEY (or IEEE_API_KEY) and institutional access.
 
@@ -1322,7 +1322,7 @@ if ieee_searcher is not None:
         """
         return await asyncio.to_thread(ieee_searcher.download_pdf, paper_id, save_path)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
     async def read_ieee_paper(paper_id: str, save_path: str = "./downloads") -> str:
         """Download and read an IEEE Xplore paper.  Requires PAPER_SEARCH_MCP_IEEE_API_KEY (or IEEE_API_KEY).
 
@@ -1339,7 +1339,7 @@ if ieee_searcher is not None:
 # Optional ACM Digital Library tools — registered only when API key is set
 # ---------------------------------------------------------------------------
 if acm_searcher is not None:
-    @mcp.tool()
+    @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
     async def search_acm(query: str, max_results: int = 10) -> List[Dict]:
         """Search ACM Digital Library for papers.  Requires PAPER_SEARCH_MCP_ACM_API_KEY (or ACM_API_KEY).
 
@@ -1351,7 +1351,7 @@ if acm_searcher is not None:
         """
         return await async_search(acm_searcher, query, max_results)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
     async def download_acm(paper_id: str, save_path: str = "./downloads") -> str:
         """Download a PDF from ACM Digital Library.  Requires PAPER_SEARCH_MCP_ACM_API_KEY (or ACM_API_KEY) and institutional access.
 
@@ -1363,7 +1363,7 @@ if acm_searcher is not None:
         """
         return await asyncio.to_thread(acm_searcher.download_pdf, paper_id, save_path)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
     async def read_acm_paper(paper_id: str, save_path: str = "./downloads") -> str:
         """Download and read an ACM Digital Library paper.  Requires PAPER_SEARCH_MCP_ACM_API_KEY (or ACM_API_KEY).
 


### PR DESCRIPTION
Add standard MCP ToolAnnotations to all tools:

- readOnlyHint: True for search/read/get tools
- readOnlyHint: False, destructiveHint: False for download tools
- openWorldHint: True for all tools (all make external API calls)

Note: tags not used since this server uses mcp.server.fastmcp which doesn't support the tags parameter.


Assisted-by: Claude (Anthropic) <https://claude.ai>