### PR TITLE
feat: DeepSeek Harness (dsh) integration for paper-search-mcp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.12', '3.13']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Compile source
+        run: python -m compileall -q paper_search_mcp tests
+
+      - name: Run deterministic tests
+        run: python -m pytest tests/test_package_entrypoints.py tests/test_config_env.py tests/test_unpaywall.py tests/test_unpaywall_source.py tests/test_dsh_bundle.py -q --tb=short

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         run: python -m compileall -q paper_search_mcp tests
 
       - name: Run deterministic tests
-        run: python -m pytest tests/test_package_entrypoints.py tests/test_config_env.py tests/test_unpaywall.py tests/test_unpaywall_source.py -q --tb=short
+        run: python -m pytest tests/test_package_entrypoints.py tests/test_config_env.py tests/test_unpaywall.py tests/test_unpaywall_source.py tests/test_dsh_bundle.py -q --tb=short
 
       - name: Build package
         run: uv build

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,8 @@ cython_debug/
 ./test_downloads
 downloads/
 test_downloads/
+
+# Node.js (dsh bundle development)
+dsh/node_modules/
+dsh/npm-debug.log*
+dsh/.npm/

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 - **Discovery + Retrieval Workflow**: Google Scholar and Crossref can be used for discovery and DOI backfilling, while open repositories and publisher links are used for lawful full-text resolution where available.
 - **OA-First Fallback Chain**: `download_with_fallback` now follows source-native download → OpenAIRE/CORE/Europe PMC/PMC discovery → Unpaywall DOI resolution → optional Sci-Hub.
 - **MCP Integration**: Compatible with MCP clients for LLM context enhancement.
-- **DeepSeek Harness (DSH) Integration**: A dsh profile bundle (clone the repo, `dsh plugin --profile web add link:./dsh`) exposing every tool as `mcp__paper-search__*`, with an optional guidance skill.
+- **DeepSeek Harness (DSH) Integration**: A dsh profile bundle (clone the repo, `npx @deepseek-ai/dsh plugin --profile web add link:./dsh`) exposing every tool as `mcp__paper-search__*`, with an optional guidance skill.
 - **Extensible Design**: Easily add new academic platforms by extending the `academic_platforms` module.
 
 ## Source Strategy
@@ -468,15 +468,15 @@ uv pip install -e ".[dev]"
 
 Paper search is available inside [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) as a profile bundle: it boots the MCP server and registers all its tools in any dsh profile as `mcp__paper-search__*`. The bundle only mounts a composition row — the MCP server itself is untouched.
 
-**Prerequisites**: [uv](https://docs.astral.sh/uv/getting-started/installation/) (the default launcher is `uvx`) and [pnpm](https://pnpm.io/installation) (`dsh plugin` forwards to pnpm). If `dsh` is not on your PATH, prefix the commands with `npx @deepseek-ai/dsh`.
+**Prerequisites**: [uv](https://docs.astral.sh/uv/getting-started/installation/) (the default launcher is `uvx`) and [pnpm](https://pnpm.io/installation) (`dsh plugin` forwards to pnpm). Commands below use the `npx @deepseek-ai/dsh` launcher (no global install needed); with a global dsh install, drop the prefix.
 
 ```bash
 git clone https://github.com/openags/paper-search-mcp.git
 cd paper-search-mcp
-dsh plugin --profile web add link:./dsh
+npx @deepseek-ai/dsh plugin --profile web add link:./dsh
 ```
 
-`link:` symlinks the live checkout into the profile, so `git pull` in the checkout is the upgrade path. Replace `web` with your profile name; a missing profile is initialized automatically. Restart the profile (`dsh web`, or relaunch) and the tools appear — e.g. `mcp__paper-search__search_papers`, `mcp__paper-search__download_with_fallback`, `mcp__paper-search__search_arxiv`.
+`link:` symlinks the live checkout into the profile, so `git pull` in the checkout is the upgrade path. Replace `web` with your profile name; a missing profile is initialized automatically. Restart the profile (`npx @deepseek-ai/dsh web`, or relaunch) and the tools appear — e.g. `mcp__paper-search__search_papers`, `mcp__paper-search__download_with_fallback`, `mcp__paper-search__search_arxiv`.
 
 **API keys**: just follow [Environment Variables](#environment-variables-env-file) — the server auto-loads `~/.config/paper-search-mcp/.env`. DSH deliberately scrubs credential-shaped ambient env vars from spawned processes, so shell exports do not reach the server; to forward variables explicitly, override the `mcp-paper-search` row in `~/.dsh/profiles/<name>/cordis.patch.yml` (a config override replaces the whole object — see `dsh/README.md` for a complete example).
 

--- a/README.md
+++ b/README.md
@@ -486,7 +486,16 @@ npx @deepseek-ai/dsh plugin --profile web add link:./dsh
 mkdir -p ~/.dsh/skills && cp -r dsh/skills/paper-search ~/.dsh/skills/
 ```
 
-If you already run paper-search-mcp through your own `@deepseek-ai/dsh-mcp-client` row, remove that row (or give one of the two a distinct `serverName`) before adding the bundle — duplicate `serverName`s fail at load. The bundle package version tracks the PyPI release it was tested with; `dsh/README.md` documents alternate launchers (`uv tool run`, `python -m`, `npx`), upgrade/removal, and development.
+**Uninstall**:
+
+```bash
+npx @deepseek-ai/dsh plugin --profile web remove paper-search-mcp-dsh
+rm -rf ~/.dsh/skills/paper-search
+```
+
+Removing the bundle reconciles it out of the composition automatically; deleting the clone afterwards leaves no trace.
+
+If you already run paper-search-mcp through your own `@deepseek-ai/dsh-mcp-client` row, remove that row (or give one of the two a distinct `serverName`) before adding the bundle — duplicate `serverName`s fail at load. The bundle package version tracks the PyPI release it was tested with; `dsh/README.md` documents alternate launchers (`uv tool run`, `python -m`, `npx`), environment forwarding, and development.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
   - [Method 5 — npx](#method-5--npx-via-smithery-cli-no-local-python-needed)
   - [Method 6 — Docker](#method-6--docker)
   - [Method 7 — Clone & run from source](#method-7--clone--run-from-source-development--recommended-for-macos-local)
+  - [DeepSeek Harness (DSH)](#deepseek-harness-dsh)
   - [Environment Variables](#environment-variables-env-file)
 - [Contributing](#contributing)
 - [Demo](#demo)
@@ -57,6 +58,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 - **Discovery + Retrieval Workflow**: Google Scholar and Crossref can be used for discovery and DOI backfilling, while open repositories and publisher links are used for lawful full-text resolution where available.
 - **OA-First Fallback Chain**: `download_with_fallback` now follows source-native download → OpenAIRE/CORE/Europe PMC/PMC discovery → Unpaywall DOI resolution → optional Sci-Hub.
 - **MCP Integration**: Compatible with MCP clients for LLM context enhancement.
+- **DeepSeek Harness (DSH) Integration**: A dsh profile bundle (clone the repo, `dsh plugin --profile web add link:./dsh`) exposing every tool as `mcp__paper-search__*`, with an optional guidance skill.
 - **Extensible Design**: Easily add new academic platforms by extending the `academic_platforms` module.
 
 ## Source Strategy
@@ -459,6 +461,32 @@ For active development, optionally install an editable copy:
 uv venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
 uv pip install -e ".[dev]"
 ```
+
+---
+
+### DeepSeek Harness (DSH)
+
+Paper search is available inside [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) as a profile bundle: it boots the MCP server and registers all its tools in any dsh profile as `mcp__paper-search__*`. The bundle only mounts a composition row — the MCP server itself is untouched.
+
+**Prerequisites**: [uv](https://docs.astral.sh/uv/getting-started/installation/) (the default launcher is `uvx`) and [pnpm](https://pnpm.io/installation) (`dsh plugin` forwards to pnpm). If `dsh` is not on your PATH, prefix the commands with `npx @deepseek-ai/dsh`.
+
+```bash
+git clone https://github.com/openags/paper-search-mcp.git
+cd paper-search-mcp
+dsh plugin --profile web add link:./dsh
+```
+
+`link:` symlinks the live checkout into the profile, so `git pull` in the checkout is the upgrade path. Replace `web` with your profile name; a missing profile is initialized automatically. Restart the profile (`dsh web`, or relaunch) and the tools appear — e.g. `mcp__paper-search__search_papers`, `mcp__paper-search__download_with_fallback`, `mcp__paper-search__search_arxiv`.
+
+**API keys**: just follow [Environment Variables](#environment-variables-env-file) — the server auto-loads `~/.config/paper-search-mcp/.env`. DSH deliberately scrubs credential-shaped ambient env vars from spawned processes, so shell exports do not reach the server; to forward variables explicitly, override the `mcp-paper-search` row in `~/.dsh/profiles/<name>/cordis.patch.yml` (a config override replaces the whole object — see `dsh/README.md` for a complete example).
+
+**Optional skill** with usage guidance (workflow, source table, tool mapping):
+
+```bash
+mkdir -p ~/.dsh/skills && cp -r dsh/skills/paper-search ~/.dsh/skills/
+```
+
+If you already run paper-search-mcp through your own `@deepseek-ai/dsh-mcp-client` row, remove that row (or give one of the two a distinct `serverName`) before adding the bundle — duplicate `serverName`s fail at load. The bundle package version tracks the PyPI release it was tested with; `dsh/README.md` documents alternate launchers (`uv tool run`, `python -m`, `npx`), upgrade/removal, and development.
 
 ---
 

--- a/dsh/LICENSE
+++ b/dsh/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 OPENAGS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -1,0 +1,76 @@
+# paper-search-mcp-dsh
+
+DeepSeek Harness ([dsh](https://github.com/deepseek-ai/deepseek-harness)) profile bundle for [paper-search-mcp](https://github.com/openags/paper-search-mcp): boots the published MCP server and registers its tools in any dsh profile as `mcp__paper-search__*`.
+
+The bundle only mounts a composition row — it never patches or replaces the MCP server itself, and its tool namespace is isolated from anything else in the profile.
+
+## Install
+
+**Prerequisites**: [uv](https://docs.astral.sh/uv/getting-started/installation/) (the default launcher is `uvx`) and [pnpm](https://pnpm.io/installation) (`dsh plugin` forwards to pnpm). If `dsh` is not on your PATH, prefix every command with `npx @deepseek-ai/dsh`, e.g. `npx @deepseek-ai/dsh plugin --profile web add ...`.
+
+Clone the paper-search-mcp repository and link the bundle into your profile:
+
+```sh
+git clone https://github.com/openags/paper-search-mcp.git
+cd paper-search-mcp
+dsh plugin --profile web add link:./dsh
+```
+
+The `link:` spec symlinks the live checkout into the profile, so the profile always reads this directory's `cordis.patch.yml` — `git pull` in the checkout is the upgrade path.
+
+Replace `web` with your profile name — any profile works; one that does not exist yet is initialized automatically. Restart the profile (`dsh web`, or relaunch) to activate. The model then sees `mcp__paper-search__search_papers`, `mcp__paper-search__download_with_fallback`, `mcp__paper-search__search_arxiv`, and the other server tools.
+
+Remove: `dsh plugin --profile web remove paper-search-mcp-dsh` (the row is reconciled out of the composition automatically).
+
+## Optional API keys
+
+The server loads `~/.config/paper-search-mcp/.env` itself at startup (see the project's [Environment Variables](https://github.com/openags/paper-search-mcp#environment-variables-env-file) section) — create that file and no dsh-side configuration is needed.
+
+DSH deliberately scrubs credential-shaped ambient env vars (and all `DSH_*` vars) from spawned children, so shell exports do **not** reach the server. To forward variables explicitly, override the `mcp-paper-search` row in `~/.dsh/profiles/<name>/cordis.patch.yml`. A config override replaces the entire object, so restate every field you want to keep:
+
+```yaml
+- id: mcp-paper-search
+  config:
+    serverName: paper-search
+    transport: stdio
+    command: uvx
+    args: ['paper-search-mcp']
+    toolCallTimeoutMs: 120000
+    env:
+      PAPER_SEARCH_MCP_UNPAYWALL_EMAIL: !!js process.env.PAPER_SEARCH_MCP_UNPAYWALL_EMAIL
+      PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY: !!js process.env.PAPER_SEARCH_MCP_SEMANTIC_SCHOLAR_API_KEY
+```
+
+## Alternate launchers
+
+The default `uvx paper-search-mcp` runs the latest PyPI release with no install. The same row override mechanism switches launchers — restate the full config:
+
+| Launcher | `command` | `args` |
+|---|---|---|
+| `uv` tool run | `uv` | `['tool', 'run', 'paper-search-mcp']` |
+| Python module | `python` | `['-m', 'paper_search_mcp.server']` |
+| npx via Smithery | `npx` | `['-y', '@smithery/cli', 'run', '@openags/paper-search-mcp']` |
+
+## Optional skill
+
+`skills/paper-search/SKILL.md` (in this repository) is a model-guidance skill (usage workflow, source table, tool mapping) — the MCP tools work without it. From the checkout:
+
+```sh
+mkdir -p ~/.dsh/skills && cp -r skills/paper-search ~/.dsh/skills/
+```
+
+## Naming and conflicts
+
+- `serverName: paper-search` namespaces every tool (`mcp__paper-search__*`). It is unique across live `@deepseek-ai/dsh-mcp-client` instances: if you already run paper-search-mcp through your own client row, remove that row or set a distinct `serverName` in one of the two — a duplicate fails the later instance at load.
+- The row id `mcp-paper-search` is the stable anchor for user overrides; avoid using it for other rows in the same profile.
+- The bundle never touches the Python server or its configuration files; uninstalling the bundle restores the profile exactly.
+
+## Versions
+
+The `package.json` version tracks the PyPI release the bundle was tested with (informational; the test suite asserts the two stay in sync).
+
+## Development
+
+- `package.json` declares `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }` — that declaration is what makes `dsh plugin` treat the package as a profile layer.
+- `cordis.patch.yml` is a loader patch that inserts the `@deepseek-ai/dsh-mcp-client` row; dsh applies bundle patches over the profile's empty root, then the user's `cordis.patch.yml` on top (last write wins per row id).
+- Installed via `link:` from a checkout, the profile reads the live patch file, so edits to `cordis.patch.yml` apply on the next profile boot.

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -56,7 +56,7 @@ The default `uvx paper-search-mcp` runs the latest PyPI release with no install.
 `skills/paper-search/SKILL.md` (in this repository) is a model-guidance skill (usage workflow, source table, tool mapping) — the MCP tools work without it. From the checkout:
 
 ```sh
-mkdir -p ~/.dsh/skills && cp -r skills/paper-search ~/.dsh/skills/
+mkdir -p ~/.dsh/skills && cp -r dsh/skills/paper-search ~/.dsh/skills/
 ```
 
 ## Naming and conflicts

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -6,21 +6,21 @@ The bundle only mounts a composition row — it never patches or replaces the MC
 
 ## Install
 
-**Prerequisites**: [uv](https://docs.astral.sh/uv/getting-started/installation/) (the default launcher is `uvx`) and [pnpm](https://pnpm.io/installation) (`dsh plugin` forwards to pnpm). If `dsh` is not on your PATH, prefix every command with `npx @deepseek-ai/dsh`, e.g. `npx @deepseek-ai/dsh plugin --profile web add ...`.
+**Prerequisites**: [uv](https://docs.astral.sh/uv/getting-started/installation/) (the default launcher is `uvx`) and [pnpm](https://pnpm.io/installation) (`dsh plugin` forwards to pnpm). Commands below use the `npx @deepseek-ai/dsh` launcher (no global install); with a global dsh install, drop the prefix.
 
 Clone the paper-search-mcp repository and link the bundle into your profile:
 
 ```sh
 git clone https://github.com/openags/paper-search-mcp.git
 cd paper-search-mcp
-dsh plugin --profile web add link:./dsh
+npx @deepseek-ai/dsh plugin --profile web add link:./dsh
 ```
 
 The `link:` spec symlinks the live checkout into the profile, so the profile always reads this directory's `cordis.patch.yml` — `git pull` in the checkout is the upgrade path.
 
-Replace `web` with your profile name — any profile works; one that does not exist yet is initialized automatically. Restart the profile (`dsh web`, or relaunch) to activate. The model then sees `mcp__paper-search__search_papers`, `mcp__paper-search__download_with_fallback`, `mcp__paper-search__search_arxiv`, and the other server tools.
+Replace `web` with your profile name — any profile works; one that does not exist yet is initialized automatically. Restart the profile (`npx @deepseek-ai/dsh web`, or relaunch) to activate. The model then sees `mcp__paper-search__search_papers`, `mcp__paper-search__download_with_fallback`, `mcp__paper-search__search_arxiv`, and the other server tools.
 
-Remove: `dsh plugin --profile web remove paper-search-mcp-dsh` (the row is reconciled out of the composition automatically).
+Remove: `npx @deepseek-ai/dsh plugin --profile web remove paper-search-mcp-dsh` (the row is reconciled out of the composition automatically).
 
 ## Optional API keys
 

--- a/dsh/cordis.patch.yml
+++ b/dsh/cordis.patch.yml
@@ -1,0 +1,32 @@
+# paper-search-mcp-dsh bundle patch.
+#
+# Inserts ONE `@deepseek-ai/dsh-mcp-client` row into the profile composition.
+# On profile boot the client spawns the published paper-search-mcp MCP server
+# over stdio and registers every tool on the model's tool set as
+# `mcp__paper-search__<tool>` (e.g. mcp__paper-search__search_papers,
+# mcp__paper-search__download_with_fallback).
+#
+# Optional API keys are picked up by the server itself from
+# `~/.config/paper-search-mcp/.env` — no env block is needed here. DSH
+# deliberately scrubs credential-shaped ambient env vars (and all DSH_*
+# vars) from spawned children, so shell exports do NOT reach the server. If
+# you must forward shell variables, or want a different launcher, override
+# the whole `config` of this row in your profile's cordis.patch.yml; a
+# config override REPLACES the entire object, so restate every field you
+# want to keep. The row id `mcp-paper-search` is the stable anchor for such
+# user overrides.
+#
+# serverName `paper-search` namespaces the tools. It is unique across live
+# dsh-mcp-client instances: if you already run paper-search-mcp through your
+# own client row, remove that row (or set a distinct serverName in one of
+# the two) — a duplicate serverName fails the later instance at load.
+
+- insert:
+    - id: mcp-paper-search
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: paper-search
+        transport: stdio
+        command: uvx
+        args: ['paper-search-mcp']
+        toolCallTimeoutMs: 120000

--- a/dsh/package.json
+++ b/dsh/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "paper-search-mcp-dsh",
+  "version": "0.1.4",
+  "description": "DeepSeek Harness (dsh) profile bundle: boots the paper-search-mcp MCP server and exposes its tools as mcp__paper-search__*.",
+  "license": "MIT",
+  "author": "P.S Zhang <pengsongzhang96@gmail.com>",
+  "keywords": [
+    "deepseek-harness",
+    "dsh",
+    "mcp",
+    "papers",
+    "academic-search",
+    "arxiv",
+    "pubmed",
+    "semantic-scholar"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openags/paper-search-mcp.git",
+    "directory": "dsh"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "dependencies": {
+    "@deepseek-ai/dsh-mcp-client": ">=0.1.0-rc.6 <0.2.0"
+  }
+}

--- a/dsh/skills/paper-search/SKILL.md
+++ b/dsh/skills/paper-search/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: paper-search
+description: Search, download, and read academic papers through the paper-search MCP tools (mcp__paper-search__*), covering arXiv, PubMed, bioRxiv, Semantic Scholar, Crossref, OpenAlex and 15+ other sources. Use when the user asks to find papers, search research literature, download a paper PDF, or extract text from a paper.
+whenToUse: Use when the user asks to find, download, or read academic papers or literature. Prefer these MCP tools over a raw web search for paper discovery.
+---
+
+# Paper Search
+
+Academic paper discovery and retrieval in this harness runs through the `mcp__paper-search__*` tools (the paper-search-mcp MCP server). Do not run the `paper-search` CLI or hand-write API requests — use these tools.
+
+## Core tools
+
+- `mcp__paper-search__search_papers` — multi-source concurrent search with deduplication and DOI backfill. Prefer it for broad queries; one call covers many sources at once.
+- `mcp__paper-search__download_with_fallback` — OA-first PDF download with a source-native → repository → Unpaywall fallback chain.
+- `mcp__paper-search__search_unpaywall` — DOI-centric open-access metadata lookup.
+
+## Source-specific tools
+
+Per source the pattern is `search_<source>` / `download_<source>` / `read_<source>_paper`, with availability varying by source. Sources: arxiv, pubmed, biorxiv, medrxiv, iacr, semantic, crossref, openalex, pmc, core, europepmc, dblp, openaire, citeseerx, doaj, base, zenodo, hal, ssrn, google_scholar. With `PAPER_SEARCH_MCP_IEEE_API_KEY` / `PAPER_SEARCH_MCP_ACM_API_KEY` configured, ieee and acm tools are registered too.
+
+For speed, prefer a targeted set (`search_arxiv`, `search_semantic`, `search_crossref`) over multi-source search when the field is clear.
+
+## Workflow
+
+1. Search: `search_papers` for broad coverage, `search_<source>` for targeted queries.
+2. Present results as a table: title, authors, year, source, DOI/URL.
+3. Full text: `read_<source>_paper`; PDF: `download_<source>` or `download_with_fallback`, then report the saved path.
+
+## Notes
+
+- Sources work without API keys; optional keys (Semantic Scholar, CORE, Unpaywall email, …) live in `~/.config/paper-search-mcp/.env` and are loaded by the server automatically.
+- Google Scholar and SSRN can be bot-blocked upstream; fall back to other sources rather than retrying.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]

--- a/tests/test_dsh_bundle.py
+++ b/tests/test_dsh_bundle.py
@@ -81,10 +81,10 @@ def test_skill_frontmatter_is_dsh_compatible() -> None:
 def test_docs_document_the_install_path() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     bundle_readme = (DSH_DIR / "README.md").read_text(encoding="utf-8")
-    assert "dsh plugin" in readme
+    assert "npx @deepseek-ai/dsh plugin --profile web add link:./dsh" in readme
     assert "mcp__paper-search__" in readme
     assert "git clone https://github.com/openags/paper-search-mcp.git" in bundle_readme
-    assert "dsh plugin --profile web add link:./dsh" in bundle_readme
+    assert "npx @deepseek-ai/dsh plugin --profile web add link:./dsh" in bundle_readme
     assert "npx @deepseek-ai/dsh" in bundle_readme
     assert "~/.config/paper-search-mcp/.env" in bundle_readme
 

--- a/tests/test_dsh_bundle.py
+++ b/tests/test_dsh_bundle.py
@@ -82,6 +82,7 @@ def test_docs_document_the_install_path() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     bundle_readme = (DSH_DIR / "README.md").read_text(encoding="utf-8")
     assert "npx @deepseek-ai/dsh plugin --profile web add link:./dsh" in readme
+    assert "npx @deepseek-ai/dsh plugin --profile web remove paper-search-mcp-dsh" in readme
     assert "mcp__paper-search__" in readme
     assert "git clone https://github.com/openags/paper-search-mcp.git" in bundle_readme
     assert "npx @deepseek-ai/dsh plugin --profile web add link:./dsh" in bundle_readme

--- a/tests/test_dsh_bundle.py
+++ b/tests/test_dsh_bundle.py
@@ -1,0 +1,93 @@
+"""Offline structural tests for the DeepSeek Harness (dsh) bundle in dsh/.
+
+These tests validate the integration contract without starting dsh or the MCP
+server: the npm bundle manifest, the loader patch that mounts the MCP client
+row, the version sync with the Python package, and the user-facing docs.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+DSH_DIR = ROOT / "dsh"
+
+
+def _read_pkg() -> dict:
+    return json.loads((DSH_DIR / "package.json").read_text(encoding="utf-8"))
+
+
+def _read_patch() -> list:
+    return yaml.safe_load((DSH_DIR / "cordis.patch.yml").read_text(encoding="utf-8"))
+
+
+def _mcp_row() -> dict:
+    patch = _read_patch()
+    rows = patch[0]["insert"]
+    row = next(row for row in rows if row["id"] == "mcp-paper-search")
+    return row
+
+
+def test_bundle_manifest_declares_patch() -> None:
+    pkg = _read_pkg()
+    assert pkg["name"] == "paper-search-mcp-dsh"
+    assert pkg["dsh"]["bundle"]["patch"] == "./cordis.patch.yml"
+    assert (DSH_DIR / pkg["dsh"]["bundle"]["patch"]).is_file()
+
+
+def test_bundle_version_syncs_with_python_package() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    assert match, "pyproject.toml must declare a project version"
+    assert _read_pkg()["version"] == match.group(1)
+
+
+def test_patch_mounts_one_mcp_client_row() -> None:
+    patch = _read_patch()
+    assert len(patch) == 1
+    insert = patch[0]["insert"]
+    assert len(insert) == 1
+    row = _mcp_row()
+    assert row["name"] == "@deepseek-ai/dsh-mcp-client"
+    assert re.fullmatch(r"[A-Za-z0-9_-]{1,32}", row["id"])
+
+
+def test_mcp_client_row_config() -> None:
+    config = _mcp_row()["config"]
+    assert config["serverName"] == "paper-search"
+    assert re.fullmatch(r"[A-Za-z0-9_-]{1,32}", config["serverName"])
+    assert config["transport"] == "stdio"
+    assert config["command"] == "uvx"
+    assert config["args"] == ["paper-search-mcp"]
+    # No env block: the server auto-loads ~/.config/paper-search-mcp/.env, and
+    # dsh scrubs ambient credential-shaped vars from spawned children. An env
+    # block with empty-string defaults would also shadow the server's own
+    # setdefault()-based .env loading.
+    assert "env" not in config
+
+
+def test_skill_frontmatter_is_dsh_compatible() -> None:
+    skill = (DSH_DIR / "skills" / "paper-search" / "SKILL.md").read_text(encoding="utf-8")
+    assert skill.startswith("---")
+    body = skill.split("---", 2)[1]
+    assert re.search(r"^name:\s+paper-search\s*$", body, re.MULTILINE)
+    assert re.search(r"^description:\s*\S", body, re.MULTILINE)
+    assert "mcp__paper-search__" in skill
+
+
+def test_docs_document_the_install_path() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    bundle_readme = (DSH_DIR / "README.md").read_text(encoding="utf-8")
+    assert "dsh plugin" in readme
+    assert "mcp__paper-search__" in readme
+    assert "git clone https://github.com/openags/paper-search-mcp.git" in bundle_readme
+    assert "dsh plugin --profile web add link:./dsh" in bundle_readme
+    assert "npx @deepseek-ai/dsh" in bundle_readme
+    assert "~/.config/paper-search-mcp/.env" in bundle_readme
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/uv.lock
+++ b/uv.lock
@@ -957,6 +957,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -969,6 +970,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "requests" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Hi! First of all — thanks for this project. I use paper-search-mcp almost daily for collecting research papers, and it has genuinely made my literature workflow much easier.

DeepSeek Harness (dsh) just released, and I wanted to keep using paper-search there too. So I built a small bridge: a dsh profile bundle that boots the MCP server and exposes every tool to the model as `mcp__paper-search__*`.

# Usage

```sh
git clone https://github.com/openags/paper-search-mcp.git
cd paper-search-mcp
npx @deepseek-ai/dsh plugin --profile web add link:./dsh
```

Restart dsh and the model gets `mcp__paper-search__search_papers`, `download_with_fallback`, and all the per-source tools. `git pull` upgrades it; one command uninstalls it. There's also an optional guidance skill.

# What's in this PR

- New `dsh/` directory (bundle + patch + docs + skill). **The MCP server itself is untouched** — this is purely additive, so nothing changes for existing users.
- `tests/test_dsh_bundle.py`: 6 offline contract tests; 19/19 deterministic tests pass.
- Real end-to-end verified on dsh 0.1.0-rc.6: install → profile boot → MCP handshake → tool discovery.
- Tool parity with other clients (Claude etc.): 57 tools without keys, 63 with IEEE/ACM keys.
- `ci.yml` runs the deterministic tests on PRs (previously they only ran on release tags); `publish.yml` adds the bundle tests to its release gate.

# Open question for you

Is this the kind of integration you'd like in this repo? I'm happy to adjust anything — naming, structure, docs, or dropping the CI changes if you'd rather keep them out. If you'd prefer I open an issue to discuss first, just say so.

Thanks for your time!