### PR TITLE
fix(server): upgrade to mcp v2

### DIFF
--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -5,7 +5,7 @@ import os
 import logging
 import re
 import httpx
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from .config import get_env
 from .academic_platforms.arxiv import ArxivSearcher
 from .academic_platforms.pubmed import PubMedSearcher
@@ -35,7 +35,7 @@ from .utils import extract_doi
 from .paper import Paper
 
 # Initialize MCP server
-mcp = FastMCP("paper_search_server")
+mcp = MCPServer("paper_search_server")
 logger = logging.getLogger(__name__)
 
 # Instances of searchers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
 dependencies = [
     "requests",
     "feedparser",
-    "fastmcp",
     "pypdf",
     "mcp[cli]>=1.6.0",
     "beautifulsoup4>=4.12.0",


### PR DESCRIPTION
I was getting the following error:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was renamed to MCPServer (from mcp.server.mcpserver import MCPServer) and other APIs changed; see the migration guide at https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver or pin 'mcp<2' to keep running v1 code.
```

This PR is a proposed fix to that error.