### PR TITLE
Pin mcp[cli]>=1.6.0,<2 to fix startup crash under mcp 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "feedparser",
     "fastmcp",
     "pypdf",
-    "mcp[cli]>=1.6.0",
+    "mcp[cli]>=1.6.0,<2",
     "beautifulsoup4>=4.12.0",
     "lxml>=4.9.0",
     "httpx[socks]>=0.28.1",

--- a/uv.lock
+++ b/uv.lock
@@ -966,7 +966,7 @@ requires-dist = [
     { name = "feedparser" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=4.9.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0,<2" },
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "requests" },


### PR DESCRIPTION
Fixes #107.

mcp 2.x renamed FastMCP to MCPServer, so `from mcp.server.fastmcp import FastMCP` raises ModuleNotFoundError at startup when uv resolves the unbounded `mcp[cli]>=1.6.0` to 2.x.

Changes:
- `pyproject.toml`: add upper bound, `mcp[cli]>=1.6.0,<2`
- `uv.lock`: regenerated with `uv lock` (one line changes)

Verification (live, MCP JSON-RPC over stdio on Windows):
- Without pin: `uvx paper-search-mcp` fails with the ModuleNotFoundError from #107
- With pin: server initializes in ~7s, registers 57 tools, `search_papers` returns abstracts from pubmed (0.9s) and arxiv (0.7s)

Migrating to `mcp.server.mcpserver.MCPServer` is the longer-term fix; this pin unblocks uvx installs immediately without changing any code paths.